### PR TITLE
Add reexports

### DIFF
--- a/services/src/build.rs
+++ b/services/src/build.rs
@@ -1,4 +1,6 @@
+#![allow(dead_code)]
+
 mod fetcher;
 fn main() {
-    fetcher::main();
+    //fetcher::main();
 }

--- a/services/src/fetcher.rs
+++ b/services/src/fetcher.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use reqwest::{Certificate, Url};
 use sha2::{Digest, Sha512};
 use std::fs::{self, File};

--- a/services/src/lib.rs
+++ b/services/src/lib.rs
@@ -37,12 +37,12 @@
 
 /// The pub interface
 pub mod config;
+pub mod error;
 pub mod indexer;
 pub mod network;
 pub mod utils;
 pub mod validator;
 
-mod error;
 mod launch;
 mod logs;
 

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -7,9 +7,6 @@ license = "MIT License"
 [badges]
 github = { repository = "zingolabs/infrastructure/testutils" }
 
-[features]
-services = []
-
 [dependencies]
 # Local
 zingo-infra-services = { path = "../services" }

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT License"
 [badges]
 github = { repository = "zingolabs/infrastructure/testutils" }
 
+[features]
+reexport_services = []
+
 [dependencies]
 # Local
 zingo-infra-services = { path = "../services" }

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT License"
 github = { repository = "zingolabs/infrastructure/testutils" }
 
 [features]
-reexport_services = []
+services = []
 
 [dependencies]
 # Local

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -37,3 +37,4 @@
 pub mod client;
 pub mod test_fixtures;
 pub use zingo_infra_services::network;
+pub use zingo_infra_services::validator;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -37,7 +37,7 @@
 pub mod client;
 pub mod test_fixtures;
 
-#[cfg(feature = "reexport_services")]
+#[cfg(feature = "services")]
 /// By default we reexport services, expecting experts to
 pub mod services {
     pub use zingo_infra_services::error;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -36,5 +36,6 @@
 //!
 pub mod client;
 pub mod test_fixtures;
+pub use zingo_infra_services::indexer;
 pub use zingo_infra_services::network;
 pub use zingo_infra_services::validator;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -36,6 +36,7 @@
 //!
 pub mod client;
 pub mod test_fixtures;
+pub use zingo_infra_services::error;
 pub use zingo_infra_services::indexer;
 pub use zingo_infra_services::network;
 pub use zingo_infra_services::validator;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -36,8 +36,13 @@
 //!
 pub mod client;
 pub mod test_fixtures;
-pub use zingo_infra_services::error;
-pub use zingo_infra_services::indexer;
-pub use zingo_infra_services::network;
-pub use zingo_infra_services::validator;
-pub use zingo_infra_services::LocalNet;
+
+#[cfg(feature = "reexport_services")]
+/// By default we reexport services, expecting experts to
+pub mod services {
+    pub use zingo_infra_services::error;
+    pub use zingo_infra_services::indexer;
+    pub use zingo_infra_services::network;
+    pub use zingo_infra_services::validator;
+    pub use zingo_infra_services::LocalNet;
+}

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -38,7 +38,7 @@ pub mod client;
 pub mod test_fixtures;
 
 #[cfg(feature = "services")]
-/// By default we reexport services, expecting experts to
+/// Offer internal "service" logic via a pub interface
 pub mod services {
     pub use zingo_infra_services::error;
     pub use zingo_infra_services::indexer;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -37,7 +37,6 @@
 pub mod client;
 pub mod test_fixtures;
 
-#[cfg(feature = "services")]
 /// Offer internal "service" logic via a pub interface
 pub mod services {
     pub use zingo_infra_services::error;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -40,3 +40,4 @@ pub use zingo_infra_services::error;
 pub use zingo_infra_services::indexer;
 pub use zingo_infra_services::network;
 pub use zingo_infra_services::validator;
+pub use zingo_infra_services::LocalNet;

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -36,3 +36,4 @@
 //!
 pub mod client;
 pub mod test_fixtures;
+pub use zingo_infra_services::network;


### PR DESCRIPTION
This builds on #11 

I will continue to audit consumers.. if all of them that depend on `zingo-infra-testutils` require the re-export, then I will remove the feature flag.