### PR TITLE
Fix get_path method bug

### DIFF
--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -92,11 +92,7 @@ impl Binaries {
 
     fn get_path(&self, cache: &Cache) -> Result<PathBuf, Error> {
         let key = self.get_key();
-        if cache.exists(&key) {
-            Ok(cache.get_path(&key))
-        } else {
-            Err(Error::ResourceNotFound)
-        }
+        Ok(cache.get_path(&key))
     }
 
     fn get_shasum(&self) -> Result<String, Error> {


### PR DESCRIPTION
There was a bug witht the `get_path` method where it would return an error if the file didnt exist yet.
