### PR TITLE
logs for Binaries get

### DIFF
--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -203,7 +203,7 @@ impl Binaries {
         )
         .expect("reqwest to ingest cert");
 
-        println!("cert ingested : {:?}", cert);
+        println!("-- Cert ingested : {:?}", cert);
 
         // let s_addr = socketaddr::new(ipaddr::v4(ipv4addr::new(9, 9, 9, 9)), 9073);
         // client deafult is idle sockets being kept-alive 90 seconds
@@ -221,7 +221,7 @@ impl Binaries {
 
         // reqwest some stuff
         let asset_url = self.get_fetch_url();
-        println!("fetching from {:?}", asset_url);
+        println!("-- Fetching from {:?}", asset_url);
         let fetch_url = Url::parse(&asset_url).expect("fetch_url to parse");
 
         let mut res = req_client
@@ -242,7 +242,7 @@ impl Binaries {
             .open(self.get_path(cache).expect("path to be loaded"))
             .expect("new binary file to be created");
         println!(
-            "new empty file for {} made. write about to start!",
+            "-- New empty file for [{}] made. write about to start!",
             self.get_name()
         );
 

--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -126,7 +126,7 @@ impl Binaries {
             println!("---- initial bytes okay!");
         } else {
             println!(
-                "---- Local copy of binary [{}] found to be IVALID (didn't match expected bytes)",
+                "---- Local copy of binary [{}] found to be INVALID (didn't match expected bytes)",
                 self.get_name()
             );
             println!("---- Removing binary");

--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -291,7 +291,7 @@ impl Binaries {
                 self.fetch(cache).await?;
             }
             Ok(true) => {
-                println!("Resource [{}] found locally.", self.get_name());
+                println!("-- Resource found locally.");
             }
             Err(e) => {
                 println!(
@@ -302,6 +302,7 @@ impl Binaries {
                 return Err(e);
             }
         }
+        println!("Verifying resource [{}]", self.get_name());
         // Verify the resource after fetching if needed
         match self.verify(cache) {
             Ok(true) => {

--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -306,16 +306,16 @@ impl Binaries {
         // Verify the resource after fetching if needed
         match self.verify(cache) {
             Ok(true) => {
-                println!("Resource [{}] verified correctly!", self.get_name());
+                println!("-- Resource [{}] verified correctly!", self.get_name());
                 return self.get_result(cache);
             }
             Ok(false) => {
-                println!("Resource [{}] invalid!", self.get_name());
+                println!("-- Resource [{}] invalid!", self.get_name());
                 return Err(Error::InvalidResource);
             }
             Err(e) => {
                 println!(
-                    "Verification failed for resource [{}]: {:?}",
+                    "-- Verification failed for resource [{}]: {:?}",
                     self.get_name(),
                     e
                 );

--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -104,12 +104,10 @@ impl Binaries {
     }
 
     fn confirm(&self, cache: &Cache) -> Result<bool, Error> {
-        println!("Im confirming...");
         Ok(cache.exists(&self.get_key()))
     }
 
     fn verify(&self, cache: &Cache) -> Result<bool, Error> {
-        println!("I'm verifying...");
         let hash = self.get_shasum()?;
         let bin_path = self.get_path(cache)?;
 
@@ -180,7 +178,6 @@ impl Binaries {
     }
 
     pub async fn fetch(&self, cache: &Cache) -> Result<(), Error> {
-        println!("I'm fetching...");
         // find locally committed cert for binary-dealer remote
         let cert: Certificate = reqwest::Certificate::from_pem(
             &read(get_manifest_dir().join("cert/cert.pem")).expect("cert path to be readable"),

--- a/fetcher-core/src/binary.rs
+++ b/fetcher-core/src/binary.rs
@@ -158,12 +158,9 @@ impl Binaries {
         // verify whole hash
         let bin = sha512sum_file(&bin_path);
 
-        println!(
-            "found sha512sum of binary. asserting hash equality of local record {}",
-            hash
-        );
-
-        println!("{:?} :: {:?}", bin, hash);
+        println!("Found sha512sum of binary. Asserting hash equality of local record");
+        println!("current : {:?}", bin);
+        println!("expected: {:?}", hash);
 
         if hash != bin {
             fs::remove_file(bin_path).expect("bin to be deleted");


### PR DESCRIPTION
Overview of the logging during the main method 'get' of Binaries.
Trying to make it clear what sub method is going on and showcase all expected/current values

- **removed 'I'm confirming/verifying/fetching' logs**
- **hash checking logs in separate lines for better readability**
- **loads of new logs**
- **verifying log and indenting for confirming sub log**
- ** indented verification result log**
- **indenting on fethc method logs**
