### PR TITLE
Update zingolib dep to `zaino_dep_005`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
 
 [[package]]
 name = "bumpalo"
@@ -3986,6 +3986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "testvectors"
+version = "0.1.0"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
+dependencies = [
+ "bip0039",
+ "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,6 +5715,7 @@ dependencies = [
  "http",
  "portpicker",
  "tempfile",
+ "testvectors",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5721,7 +5731,7 @@ dependencies = [
 [[package]]
 name = "zingo-memo"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
 dependencies = [
  "zcash_address 0.6.0",
  "zcash_client_backend",
@@ -5733,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "zingo-netutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
 dependencies = [
  "http",
  "http-body",
@@ -5753,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "zingo-status"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
 dependencies = [
  "zcash_primitives 0.19.0 (git+https://github.com/zingolabs/librustzcash.git?tag=zcash_client_sqlite-0.12.1_plus_zingolabs_changes-test_2)",
 ]
@@ -5761,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "zingo-sync"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
 dependencies = [
  "base58",
  "crossbeam-channel",
@@ -5792,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_004#f9f3e5f6da261ec6b7bd1282905534fdc328cb41"
+source = "git+https://github.com/zingolabs/zingolib.git?tag=zaino_dep_005#965e81228d3a1d99b76c1e3c71202d8fdbbd41dc"
 dependencies = [
  "append-only-vec",
  "base58",
@@ -5841,6 +5851,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "test-case",
+ "testvectors",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,6 @@ zcash_protocol = { git = "https://github.com/zingolabs/librustzcash.git", tag = 
 zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git" }
 zebra-node-services = { git = "https://github.com/ZcashFoundation/zebra.git" }
 zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git" }
-zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_004" }
-zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_004" }
+zingo-netutils = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_005" }
+zingolib = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_005" }
+testvectors = { git = "https://github.com/zingolabs/zingolib.git", tag = "zaino_dep_005" }

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -13,6 +13,7 @@ zingo-infra-services = { path = "../services" }
 # Zingo
 zingo-netutils = { workspace = true }
 zingolib = { workspace = true, features = ["test-elevation"] }
+testvectors = { workspace = true }
 #Zcash
 zcash_client_backend = { workspace = true }
 zcash_protocol = { workspace = true }

--- a/testutils/src/client.rs
+++ b/testutils/src/client.rs
@@ -3,12 +3,12 @@
 use std::path::PathBuf;
 
 use portpicker::Port;
+use testvectors::seeds;
 use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
 use zingo_infra_services::network;
 use zingo_netutils::{GetClientError, GrpcConnector, UnderlyingService};
 use zingolib::{
     config::RegtestNetwork, lightclient::LightClient, testutils::scenarios::setup::ClientBuilder,
-    testvectors::seeds,
 };
 
 /// Builds a client for creating RPC requests to the indexer/light-node

--- a/testutils/src/test_fixtures.rs
+++ b/testutils/src/test_fixtures.rs
@@ -21,6 +21,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use testvectors::REG_O_ADDR_FROM_ABANDONART;
 use tokio::sync::mpsc::unbounded_channel;
 use zcash_client_backend::proto;
 use zcash_primitives::transaction::Transaction;
@@ -32,7 +33,6 @@ use zingolib::{
     config::{ChainType, RegtestNetwork},
     lightclient::LightClient,
     testutils::lightclient::{from_inputs, get_base_address},
-    testvectors::REG_O_ADDR_FROM_ABANDONART,
     wallet::data::summaries::TransactionSummaryInterface,
 };
 

--- a/testutils/tests/integration.rs
+++ b/testutils/tests/integration.rs
@@ -2,10 +2,9 @@ use std::path::PathBuf;
 
 use zcash_protocol::{PoolType, ShieldedProtocol};
 
-use zingolib::{
-    testutils::lightclient::{from_inputs, get_base_address},
-    testvectors::REG_O_ADDR_FROM_ABANDONART,
-};
+use testvectors::REG_O_ADDR_FROM_ABANDONART;
+
+use zingolib::testutils::lightclient::{from_inputs, get_base_address};
 
 use zingo_infra_testutils::client;
 


### PR DESCRIPTION
Updates zingolib dep to `zaino_dep_005` (to include coinbase spend fix).
Updates testutils for zinglib changes - testvectors moved to separate crate in zinglib.
