### PR TITLE
zaino config and launch

### DIFF
--- a/services/src/indexer.rs
+++ b/services/src/indexer.rs
@@ -32,6 +32,8 @@ pub struct ZainodConfig {
     pub listen_port: Option<Port>,
     /// Validator RPC port
     pub validator_port: Port,
+    /// Chain cache path
+    pub chain_cache: Option<PathBuf>,
     /// Network type.
     pub network: Network,
 }
@@ -118,11 +120,20 @@ impl Indexer for Zainod {
 
     fn launch(config: Self::Config) -> Result<Self, LaunchError> {
         let logs_dir = tempfile::tempdir().unwrap();
+        let data_dir = tempfile::tempdir().unwrap();
 
         let port = network::pick_unused_port(config.listen_port);
         let config_dir = tempfile::tempdir().unwrap();
+
+        let cache_dir = if let Some(cache) = config.chain_cache.clone() {
+            cache
+        } else {
+            data_dir.path().to_path_buf()
+        };
+
         let config_file_path = config::zainod(
             config_dir.path(),
+            cache_dir,
             port,
             config.validator_port,
             config.network,
@@ -150,7 +161,7 @@ impl Indexer for Zainod {
             &mut handle,
             &logs_dir,
             None,
-            &["Server Ready."],
+            &["Zaino Indexer started successfully."],
             &["Error:"],
             &[],
         )?;

--- a/testutils/src/test_fixtures.rs
+++ b/testutils/src/test_fixtures.rs
@@ -243,6 +243,7 @@ pub async fn get_lightd_info(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -350,6 +351,7 @@ pub async fn get_latest_block(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -414,6 +416,7 @@ pub async fn get_block(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -475,6 +478,7 @@ pub async fn get_block_out_of_bounds(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -537,6 +541,7 @@ pub async fn get_block_nullifiers(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -606,6 +611,7 @@ pub async fn get_block_range_nullifiers(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -689,6 +695,7 @@ pub async fn get_block_range_nullifiers_reverse(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -772,6 +779,7 @@ pub async fn get_block_range_lower(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -855,6 +863,7 @@ pub async fn get_block_range_upper(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -938,6 +947,7 @@ pub async fn get_block_range_reverse(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1021,6 +1031,7 @@ pub async fn get_block_range_out_of_bounds(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1129,6 +1140,7 @@ pub async fn get_transaction(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1209,6 +1221,7 @@ pub async fn send_transaction(
             zainod_bin: zainod_bin.clone(),
             listen_port: None,
             validator_port: 0,
+            chain_cache: None,
             network: network::Network::Regtest,
         },
         ZcashdConfig {
@@ -1265,6 +1278,7 @@ pub async fn send_transaction(
             zainod_bin,
             listen_port: None,
             validator_port: 0,
+            chain_cache: None,
             network: network::Network::Regtest,
         },
         ZcashdConfig {
@@ -1366,6 +1380,7 @@ pub async fn get_taddress_txids_all(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1479,6 +1494,7 @@ pub async fn get_taddress_txids_lower(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1592,6 +1608,7 @@ pub async fn get_taddress_txids_upper(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1705,6 +1722,7 @@ pub async fn get_taddress_balance(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1777,6 +1795,7 @@ pub async fn get_taddress_balance_stream(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1851,6 +1870,7 @@ pub async fn get_mempool_tx(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -1994,6 +2014,7 @@ pub async fn get_mempool_stream_zingolib_mempool_monitor(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -2167,6 +2188,7 @@ pub async fn get_mempool_stream(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -2499,6 +2521,7 @@ pub async fn get_tree_state_by_height(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -2568,6 +2591,7 @@ pub async fn get_tree_state_by_hash(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -2647,6 +2671,7 @@ pub async fn get_tree_state_out_of_bounds(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -2713,6 +2738,7 @@ pub async fn get_latest_tree_state(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -2797,6 +2823,7 @@ pub async fn get_subtree_roots_sapling(
         zainod_bin,
         listen_port: None,
         validator_port: zebrad.rpc_listen_port(),
+        chain_cache: Some(utils::chain_cache_dir().join("get_subtree_roots_sapling")),
         network,
     })
     .unwrap();
@@ -2899,6 +2926,7 @@ pub async fn get_subtree_roots_orchard(
         zainod_bin,
         listen_port: None,
         validator_port: zebrad.rpc_listen_port(),
+        chain_cache: Some(utils::chain_cache_dir().join("get_subtree_roots_orchard")),
         network,
     })
     .unwrap();
@@ -2980,6 +3008,7 @@ pub async fn get_address_utxos_all(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3054,6 +3083,7 @@ pub async fn get_address_utxos_lower(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3129,6 +3159,7 @@ pub async fn get_address_utxos_upper(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3204,6 +3235,7 @@ pub async fn get_address_utxos_out_of_bounds(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3278,6 +3310,7 @@ pub async fn get_address_utxos_stream_all(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3360,6 +3393,7 @@ pub async fn get_address_utxos_stream_lower(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3443,6 +3477,7 @@ pub async fn get_address_utxos_stream_upper(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();
@@ -3526,6 +3561,7 @@ pub async fn get_address_utxos_stream_out_of_bounds(
         zainod_bin,
         listen_port: None,
         validator_port: zcashd.port(),
+        chain_cache: None,
         network: network::Network::Regtest,
     })
     .unwrap();

--- a/testutils/src/test_fixtures.rs
+++ b/testutils/src/test_fixtures.rs
@@ -23,7 +23,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use testvectors::REG_O_ADDR_FROM_ABANDONART;
 use tokio::sync::mpsc::unbounded_channel;
-use zcash_client_backend::proto;
+use zcash_client_backend::proto::{self, compact_formats::CompactBlock};
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::{
     consensus::{BlockHeight, BranchId},
@@ -362,6 +362,8 @@ pub async fn get_latest_block(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let mut zainod_client = client::build_client(network::localhost_uri(zainod.port()))
         .await
         .unwrap();
@@ -427,6 +429,8 @@ pub async fn get_block(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_id = proto::service::BlockId {
         height: 5,
         hash: vec![],
@@ -443,6 +447,11 @@ pub async fn get_block(
         .unwrap();
     let request = tonic::Request::new(block_id.clone());
     let lwd_response = lwd_client.get_block(request).await.unwrap().into_inner();
+
+    let lwd_response = CompactBlock {
+        proto_version: 4,
+        ..lwd_response.clone()
+    };
 
     println!("Asserting GetBlock responses...");
 
@@ -488,6 +497,8 @@ pub async fn get_block_out_of_bounds(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let block_id = proto::service::BlockId {
         height: 20,
@@ -552,6 +563,8 @@ pub async fn get_block_nullifiers(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_id = proto::service::BlockId {
         height: 5,
         hash: vec![],
@@ -576,6 +589,11 @@ pub async fn get_block_nullifiers(
         .await
         .unwrap()
         .into_inner();
+
+    let lwd_response = CompactBlock {
+        proto_version: 4,
+        ..lwd_response.clone()
+    };
 
     println!("Asserting GetBlockNullifiers responses...");
 
@@ -622,6 +640,8 @@ pub async fn get_block_range_nullifiers(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_range = proto::service::BlockRange {
         start: Some(proto::service::BlockId {
             height: 1,
@@ -658,7 +678,12 @@ pub async fn get_block_range_nullifiers(
         .into_inner();
     let mut lwd_blocks = Vec::new();
     while let Some(compact_block) = lwd_response.message().await.unwrap() {
-        lwd_blocks.push(compact_block);
+        let cleaned_block = CompactBlock {
+            proto_version: 4,
+            ..compact_block.clone()
+        };
+
+        lwd_blocks.push(cleaned_block);
     }
 
     println!("Asserting GetBlockRangeNullifiers responses...");
@@ -706,6 +731,8 @@ pub async fn get_block_range_nullifiers_reverse(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_range = proto::service::BlockRange {
         start: Some(proto::service::BlockId {
             height: 10,
@@ -742,7 +769,12 @@ pub async fn get_block_range_nullifiers_reverse(
         .into_inner();
     let mut lwd_blocks = Vec::new();
     while let Some(compact_block) = lwd_response.message().await.unwrap() {
-        lwd_blocks.push(compact_block);
+        let cleaned_block = CompactBlock {
+            proto_version: 4,
+            ..compact_block.clone()
+        };
+
+        lwd_blocks.push(cleaned_block);
     }
 
     println!("Asserting GetBlockRangeNullifiers responses...");
@@ -790,6 +822,8 @@ pub async fn get_block_range_lower(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_range = proto::service::BlockRange {
         start: Some(proto::service::BlockId {
             height: 1,
@@ -826,7 +860,12 @@ pub async fn get_block_range_lower(
         .into_inner();
     let mut lwd_blocks = Vec::new();
     while let Some(compact_block) = lwd_response.message().await.unwrap() {
-        lwd_blocks.push(compact_block);
+        let cleaned_block = CompactBlock {
+            proto_version: 4,
+            ..compact_block.clone()
+        };
+
+        lwd_blocks.push(cleaned_block);
     }
 
     println!("Asserting GetBlockRange responses...");
@@ -874,6 +913,8 @@ pub async fn get_block_range_upper(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_range = proto::service::BlockRange {
         start: Some(proto::service::BlockId {
             height: 4,
@@ -910,7 +951,11 @@ pub async fn get_block_range_upper(
         .into_inner();
     let mut lwd_blocks = Vec::new();
     while let Some(compact_block) = lwd_response.message().await.unwrap() {
-        lwd_blocks.push(compact_block);
+        let cleaned_block = CompactBlock {
+            proto_version: 4,
+            ..compact_block.clone()
+        };
+        lwd_blocks.push(cleaned_block);
     }
 
     println!("Asserting GetBlockRange responses...");
@@ -958,6 +1003,8 @@ pub async fn get_block_range_reverse(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_range = proto::service::BlockRange {
         start: Some(proto::service::BlockId {
             height: 10,
@@ -994,7 +1041,12 @@ pub async fn get_block_range_reverse(
         .into_inner();
     let mut lwd_blocks = Vec::new();
     while let Some(compact_block) = lwd_response.message().await.unwrap() {
-        lwd_blocks.push(compact_block);
+        let cleaned_block = CompactBlock {
+            proto_version: 4,
+            ..compact_block.clone()
+        };
+
+        lwd_blocks.push(cleaned_block);
     }
 
     println!("Asserting GetBlockRange responses...");
@@ -1041,6 +1093,8 @@ pub async fn get_block_range_out_of_bounds(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let block_range = proto::service::BlockRange {
         start: Some(proto::service::BlockId {
@@ -1092,7 +1146,12 @@ pub async fn get_block_range_out_of_bounds(
             None
         }
     } {
-        lwd_blocks.push(compact_block);
+        let cleaned_block = CompactBlock {
+            proto_version: 4,
+            ..compact_block.clone()
+        };
+
+        lwd_blocks.push(cleaned_block);
     }
 
     let lwd_err_status = lwd_err_status.unwrap();
@@ -1151,6 +1210,8 @@ pub async fn get_transaction(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     // TODO: get txid from chain cache
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (faucet, recipient) =
@@ -1167,6 +1228,8 @@ pub async fn get_transaction(
     .await
     .unwrap();
     zcashd.generate_blocks(1).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let tx_filter = proto::service::TxFilter {
         block: None,
@@ -1235,6 +1298,8 @@ pub async fn send_transaction(
     )
     .await;
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (faucet, recipient) = client::build_lightclients(
         lightclient_dir.path().to_path_buf(),
@@ -1253,6 +1318,8 @@ pub async fn send_transaction(
     .await
     .unwrap();
     local_net.validator().generate_blocks(1).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let tx_filter = proto::service::TxFilter {
         block: None,
@@ -1273,6 +1340,8 @@ pub async fn send_transaction(
 
     drop(local_net);
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let local_net = LocalNet::<Zainod, Zcashd>::launch(
         ZainodConfig {
             zainod_bin,
@@ -1292,6 +1361,8 @@ pub async fn send_transaction(
     )
     .await;
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (faucet, recipient) = client::build_lightclients(
         lightclient_dir.path().to_path_buf(),
@@ -1310,6 +1381,8 @@ pub async fn send_transaction(
     .await
     .unwrap();
     local_net.validator().generate_blocks(1).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let tx_filter = proto::service::TxFilter {
         block: None,
@@ -1390,6 +1463,8 @@ pub async fn get_taddress_txids_all(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let chain_type = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
 
@@ -1505,6 +1580,8 @@ pub async fn get_taddress_txids_lower(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let chain_type = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
 
     let block_range = proto::service::BlockRange {
@@ -1618,6 +1695,8 @@ pub async fn get_taddress_txids_upper(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let chain_type = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
 
@@ -1733,6 +1812,8 @@ pub async fn get_taddress_balance(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let address_list = proto::service::AddressList {
         addresses: vec![
             "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i".to_string(),
@@ -1805,6 +1886,8 @@ pub async fn get_taddress_balance_stream(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let address_list = vec![
         proto::service::Address {
@@ -1881,6 +1964,8 @@ pub async fn get_mempool_tx(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (faucet, recipient) =
         client::build_lightclients(lightclient_dir.path().to_path_buf(), lightwalletd.port()).await;
@@ -1906,6 +1991,8 @@ pub async fn get_mempool_tx(
     )
     .await
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     recipient.do_sync(false).await.unwrap();
     let txids_3 = from_inputs::quick_send(
@@ -2025,6 +2112,8 @@ pub async fn get_mempool_stream_zingolib_mempool_monitor(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (faucet, recipient) =
         client::build_lightclients(lightclient_dir.path().to_path_buf(), lightwalletd.port()).await;
@@ -2050,6 +2139,8 @@ pub async fn get_mempool_stream_zingolib_mempool_monitor(
     )
     .await
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     recipient.do_sync(false).await.unwrap();
     let _txids_3 = from_inputs::quick_send(
@@ -2077,13 +2168,21 @@ pub async fn get_mempool_stream_zingolib_mempool_monitor(
     drop(recipient);
     drop(faucet);
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (_faucet, recipient) =
         client::build_lightclients(lightclient_dir.path().to_path_buf(), zainod.port()).await;
 
     let recipient = Arc::new(recipient);
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     recipient.do_sync(false).await.unwrap();
     LightClient::start_mempool_monitor(recipient.clone()).unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     recipient.do_sync(false).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     let zainod_tx_summaries = recipient.detailed_transaction_summaries().await;
@@ -2093,13 +2192,21 @@ pub async fn get_mempool_stream_zingolib_mempool_monitor(
     drop(recipient);
     drop(_faucet);
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (_faucet, recipient) =
         client::build_lightclients(lightclient_dir.path().to_path_buf(), lightwalletd.port()).await;
 
     let recipient = Arc::new(recipient);
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     recipient.do_sync(false).await.unwrap();
     LightClient::start_mempool_monitor(recipient.clone()).unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     recipient.do_sync(false).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     let lwd_tx_summaries = recipient.detailed_transaction_summaries().await;
@@ -2199,6 +2306,8 @@ pub async fn get_mempool_stream(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     // start mempool tasks
     let (zainod_sender, mut zainod_receiver) =
         unbounded_channel::<proto::service::RawTransaction>();
@@ -2241,6 +2350,8 @@ pub async fn get_mempool_stream(
         }
     });
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     // send txs to mempool
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (faucet, recipient) =
@@ -2267,6 +2378,8 @@ pub async fn get_mempool_stream(
     )
     .await
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // receive txs from mempool
     let chain_type = ChainType::Regtest(RegtestNetwork::all_upgrades_active());
@@ -2327,6 +2440,8 @@ pub async fn get_mempool_stream(
     assert_eq!(&lwd_txs[1].txid(), txids[1]);
     assert_eq!(zainod_txs, lwd_txs);
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     // send more txs to mempool
     recipient.do_sync(false).await.unwrap();
     let txids_3 = from_inputs::quick_send(
@@ -2350,6 +2465,8 @@ pub async fn get_mempool_stream(
     )
     .await
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // receive txs from mempool
     while let Some(raw_tx) = zainod_receiver.recv().await {
@@ -2412,12 +2529,17 @@ pub async fn get_mempool_stream(
     drop(recipient);
     drop(faucet);
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (_faucet, recipient) =
         client::build_lightclients(lightclient_dir.path().to_path_buf(), zainod.port()).await;
 
     let recipient = Arc::new(recipient);
     LightClient::start_mempool_monitor(recipient.clone()).unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     recipient.do_sync(false).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     let zainod_tx_summaries = recipient.detailed_transaction_summaries().await;
@@ -2427,12 +2549,17 @@ pub async fn get_mempool_stream(
     drop(recipient);
     drop(_faucet);
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let lightclient_dir = tempfile::tempdir().unwrap();
     let (_faucet, recipient) =
         client::build_lightclients(lightclient_dir.path().to_path_buf(), lightwalletd.port()).await;
 
     let recipient = Arc::new(recipient);
     LightClient::start_mempool_monitor(recipient.clone()).unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     recipient.do_sync(false).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     let lwd_tx_summaries = recipient.detailed_transaction_summaries().await;
@@ -2532,6 +2659,8 @@ pub async fn get_tree_state_by_height(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_id = proto::service::BlockId {
         height: 5,
         hash: vec![],
@@ -2601,6 +2730,8 @@ pub async fn get_tree_state_by_hash(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let block_id = proto::service::BlockId {
         height: 5,
@@ -2682,6 +2813,8 @@ pub async fn get_tree_state_out_of_bounds(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let block_id = proto::service::BlockId {
         height: 20,
         hash: vec![],
@@ -2748,6 +2881,8 @@ pub async fn get_latest_tree_state(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let mut zainod_client = client::build_client(network::localhost_uri(zainod.port()))
         .await
@@ -3019,6 +3154,8 @@ pub async fn get_address_utxos_all(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
             "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i".to_string(),
@@ -3093,6 +3230,8 @@ pub async fn get_address_utxos_lower(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
@@ -3170,6 +3309,8 @@ pub async fn get_address_utxos_upper(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
             "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i".to_string(),
@@ -3246,6 +3387,8 @@ pub async fn get_address_utxos_out_of_bounds(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
             "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i".to_string(),
@@ -3320,6 +3463,8 @@ pub async fn get_address_utxos_stream_all(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
@@ -3403,6 +3548,8 @@ pub async fn get_address_utxos_stream_lower(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
@@ -3488,6 +3635,8 @@ pub async fn get_address_utxos_stream_upper(
     })
     .unwrap();
 
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![
             "tmFLszfkjgim4zoUMAXpuohnFBAKy99rr2i".to_string(),
@@ -3571,6 +3720,8 @@ pub async fn get_address_utxos_stream_out_of_bounds(
         zcashd_conf: zcashd.config_path(),
     })
     .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let address_utxos_arg = proto::service::GetAddressUtxosArg {
         addresses: vec![

--- a/testutils/tests/integration.rs
+++ b/testutils/tests/integration.rs
@@ -2,10 +2,8 @@ use std::path::PathBuf;
 
 use zcash_protocol::{PoolType, ShieldedProtocol};
 
-use zingolib::{
-    testutils::lightclient::{from_inputs, get_base_address},
-    testvectors::REG_O_ADDR_FROM_ABANDONART,
-};
+use testvectors::REG_O_ADDR_FROM_ABANDONART;
+use zingolib::testutils::lightclient::{from_inputs, get_base_address};
 
 use zingo_infra_testutils::client;
 
@@ -90,6 +88,7 @@ async fn launch_localnet_zainod_zcashd() {
             zainod_bin: ZAINOD_BIN,
             listen_port: None,
             validator_port: 0,
+            chain_cache: None,
             network: network::Network::Regtest,
         },
         ZcashdConfig {
@@ -118,6 +117,7 @@ async fn launch_localnet_zainod_zebrad() {
             zainod_bin: ZAINOD_BIN,
             listen_port: None,
             validator_port: 0,
+            chain_cache: None,
             network: network::Network::Regtest,
         },
         ZebradConfig {
@@ -195,7 +195,6 @@ async fn launch_localnet_lightwalletd_zebrad() {
     local_net.indexer().print_stderr();
 }
 
-#[ignore = "slow"]
 #[tokio::test]
 async fn zainod_zcashd_basic_send() {
     tracing_subscriber::fmt().init();
@@ -205,6 +204,7 @@ async fn zainod_zcashd_basic_send() {
             zainod_bin: ZAINOD_BIN,
             listen_port: None,
             validator_port: 0,
+            chain_cache: None,
             network: network::Network::Regtest,
         },
         ZcashdConfig {
@@ -224,6 +224,7 @@ async fn zainod_zcashd_basic_send() {
         local_net.indexer().port(),
     )
     .await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     faucet.do_sync(false).await.unwrap();
     from_inputs::quick_send(
@@ -237,6 +238,8 @@ async fn zainod_zcashd_basic_send() {
     .await
     .unwrap();
     local_net.validator().generate_blocks(1).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
     faucet.do_sync(false).await.unwrap();
     recipient.do_sync(false).await.unwrap();
 
@@ -252,7 +255,7 @@ async fn zainod_zcashd_basic_send() {
     println!("recipient balance:");
     println!("{:?}\n", recipient_balance);
 }
-#[ignore = "flake"]
+
 #[tokio::test]
 async fn zainod_zebrad_basic_send() {
     tracing_subscriber::fmt().init();
@@ -262,6 +265,7 @@ async fn zainod_zebrad_basic_send() {
             zainod_bin: ZAINOD_BIN,
             listen_port: None,
             validator_port: 0,
+            chain_cache: None,
             network: network::Network::Regtest,
         },
         ZebradConfig {
@@ -284,9 +288,13 @@ async fn zainod_zebrad_basic_send() {
     .await;
 
     local_net.validator().generate_blocks(100).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+
     faucet.do_sync(false).await.unwrap();
     faucet.quick_shield().await.unwrap();
     local_net.validator().generate_blocks(1).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
     faucet.do_sync(false).await.unwrap();
 
     from_inputs::quick_send(
@@ -300,6 +308,8 @@ async fn zainod_zebrad_basic_send() {
     .await
     .unwrap();
     local_net.validator().generate_blocks(1).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
     faucet.do_sync(false).await.unwrap();
     recipient.do_sync(false).await.unwrap();
 
@@ -316,7 +326,6 @@ async fn zainod_zebrad_basic_send() {
     println!("{:?}\n", recipient_balance);
 }
 
-#[ignore = "slow"]
 #[tokio::test]
 async fn lightwalletd_zcashd_basic_send() {
     tracing_subscriber::fmt().init();
@@ -374,7 +383,6 @@ async fn lightwalletd_zcashd_basic_send() {
     println!("{:?}\n", recipient_balance);
 }
 
-#[ignore = "slow"]
 #[tokio::test]
 async fn lightwalletd_zebrad_basic_send() {
     tracing_subscriber::fmt().init();


### PR DESCRIPTION
Updates zaino config write and launch method for zaino::dev.
Updates tests where necessary.
Fixes bet_block tests

- built on top of #71

- NOTE can we create a `zaino_dep_005` release tag once this lands?