### PR TITLE
Bump lrz crates in `services` to `d387aed`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.2.2"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
+dependencies = [
+ "blake2b_simd",
+ "core2",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1089,14 @@ name = "f4jumble"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2671,7 +2688,7 @@ dependencies = [
  "tracing",
  "zcash_address 0.7.1",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.8.1",
  "zcash_note_encryption",
  "zcash_primitives 0.22.0",
@@ -5291,8 +5308,8 @@ dependencies = [
  "bech32",
  "bs58",
  "core2",
- "f4jumble",
- "zcash_encoding",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.5.1",
 ]
 
@@ -5305,9 +5322,22 @@ dependencies = [
  "bech32",
  "bs58",
  "core2",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol 0.6.1",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
+dependencies = [
+ "bech32",
+ "bs58",
+ "core2",
+ "f4jumble 0.1.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_encoding 0.3.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
 ]
 
 [[package]]
@@ -5347,7 +5377,7 @@ dependencies = [
  "tracing",
  "which 6.0.3",
  "zcash_address 0.7.1",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.8.1",
  "zcash_note_encryption",
  "zcash_primitives 0.22.0",
@@ -5362,6 +5392,15 @@ name = "zcash_encoding"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+dependencies = [
+ "core2",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
 dependencies = [
  "core2",
  "nonempty",
@@ -5402,7 +5441,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.7.1",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.5.1",
  "zcash_transparent 0.2.3",
  "zip32",
@@ -5427,10 +5466,10 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.9.0",
- "zcash_encoding",
- "zcash_protocol 0.6.1",
- "zcash_transparent 0.4.0",
+ "zcash_address 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
 ]
 
@@ -5458,7 +5497,7 @@ dependencies = [
  "bs58",
  "core2",
  "document-features",
- "equihash",
+ "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "fpe",
  "getset",
@@ -5479,7 +5518,7 @@ dependencies = [
  "subtle",
  "tracing",
  "zcash_address 0.7.1",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
  "zcash_protocol 0.5.1",
  "zcash_spec",
@@ -5500,7 +5539,7 @@ dependencies = [
  "core2",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash",
+ "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "fpe",
  "getset",
@@ -5520,12 +5559,52 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "tracing",
- "zcash_address 0.9.0",
- "zcash_encoding",
+ "zcash_address 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol 0.6.1",
+ "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_spec",
- "zcash_transparent 0.4.0",
+ "zcash_transparent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.24.0"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
+dependencies = [
+ "bip32",
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "bs58",
+ "core2",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash 0.2.2 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "ripemd 0.1.3",
+ "sapling-crypto",
+ "sha2 0.10.9",
+ "subtle",
+ "tracing",
+ "zcash_address 0.9.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_encoding 0.3.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_spec",
+ "zcash_transparent 0.4.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
  "zip32",
 ]
 
@@ -5572,7 +5651,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives 0.24.0",
+ "zcash_primitives 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5592,6 +5671,17 @@ name = "zcash_protocol"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cfe9e3fb08e6851efe3d0ced457e4cb2c305daa928f64cb0d70c040f8f8336"
+dependencies = [
+ "core2",
+ "document-features",
+ "hex",
+ "memuse",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.6.1"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
 dependencies = [
  "core2",
  "document-features",
@@ -5644,7 +5734,7 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.7.1",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_protocol 0.5.1",
  "zcash_spec",
  "zip32",
@@ -5667,9 +5757,30 @@ dependencies = [
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
- "zcash_address 0.9.0",
- "zcash_encoding",
- "zcash_protocol 0.6.1",
+ "zcash_address 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_transparent"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b#d387aed7e04e881dbe30c6ff8b26a96c834c094b"
+dependencies = [
+ "bip32",
+ "blake2b_simd",
+ "bs58",
+ "core2",
+ "getset",
+ "hex",
+ "ripemd 0.1.3",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.9.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_encoding 0.3.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
  "zcash_spec",
  "zip32",
 ]
@@ -5691,7 +5802,7 @@ dependencies = [
  "chrono",
  "dirs 6.0.0",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
@@ -5724,13 +5835,13 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.9.0",
- "zcash_encoding",
+ "zcash_address 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.24.0",
- "zcash_protocol 0.6.1",
- "zcash_transparent 0.4.0",
+ "zcash_primitives 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5857,11 +5968,11 @@ dependencies = [
  "tower 0.4.13",
  "tracing",
  "which 8.0.0",
- "zcash_address 0.9.0",
+ "zcash_address 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.10.1",
- "zcash_primitives 0.24.0",
- "zcash_protocol 0.6.1",
- "zcash_transparent 0.4.0",
+ "zcash_primitives 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_transparent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -5877,7 +5988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76a2e972e414caa3635b8c2d21f20c21a71c69f76b37bf7419d97ed0c2277e7"
 dependencies = [
  "thiserror 2.0.12",
- "zcash_primitives 0.24.0",
+ "zcash_primitives 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_script",
  "zebra-chain",
 ]
@@ -6026,8 +6137,8 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
- "zcash_primitives 0.22.0",
- "zcash_protocol 0.5.1",
+ "zcash_primitives 0.24.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
+ "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
@@ -6061,7 +6172,7 @@ source = "git+https://github.com/zingolabs/zingolib.git?tag=2.0.0-beta2#2edd282d
 dependencies = [
  "zcash_address 0.7.1",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.8.1",
  "zcash_primitives 0.22.0",
 ]
@@ -6164,7 +6275,7 @@ dependencies = [
  "tracing-subscriber",
  "zcash_address 0.7.1",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys 0.8.1",
  "zcash_primitives 0.22.0",
  "zcash_proofs 0.22.0",

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -9,8 +9,8 @@ github = { repository = "zingolabs/infrastructure/services" }
 
 [dependencies]
 # Zcash
-zcash_primitives = { workspace = true }
-zcash_protocol = { workspace = true }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "d387aed7e04e881dbe30c6ff8b26a96c834c094b" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "d387aed7e04e881dbe30c6ff8b26a96c834c094b" }
 # Zebra
 zebra-node-services = { workspace = true }
 zebra-rpc = { workspace = true }

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -32,6 +32,7 @@ pub(crate) fn zcashd(
     let canopy_activation_height = activation_heights.canopy;
     let nu5_activation_height = activation_heights.nu5;
     let nu6_activation_height = activation_heights.nu6;
+    let nu6_1_activation_height = activation_heights.nu6_1;
 
     config_file.write_all(format!("\
 ### Blockchain Configuration
@@ -43,6 +44,7 @@ nuparams=f5b9230b:{heartwood_activation_height} # Heartwood
 nuparams=e9ff75a6:{canopy_activation_height} # Canopy
 nuparams=c2d6d0b4:{nu5_activation_height} # NU5 (Orchard)
 nuparams=c8e71055:{nu6_activation_height} # NU6
+nuparams=4dec4df0:{nu6_1_activation_height} # NU6.1
 
 ### MetaData Storage and Retrieval
 # txindex:
@@ -105,6 +107,7 @@ pub(crate) fn zebrad(
     }
     let nu5_activation_height: u32 = activation_heights.nu5.into();
     let nu6_activation_height: u32 = activation_heights.nu6.into();
+    let nu6_1_activation_height: u32 = activation_heights.nu6_1.into();
 
     let chain_cache = cache_dir.to_str().unwrap();
 
@@ -185,7 +188,8 @@ miner_address = \"{miner_address}\"
 # pre-nu5 activation heights of greater than 1 are not currently supported for regtest mode
 Canopy = 1
 NU5 = {nu5_activation_height}
-NU6 = {nu6_activation_height}"
+NU6 = {nu6_activation_height}
+NU6.1 = {nu6_1_activation_height}"
             )
             .as_bytes(),
         )?;

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -404,6 +404,7 @@ i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1";
             canopy: 5.into(),
             nu5: 6.into(),
             nu6: 7.into(),
+            nu6_1: 8.into(),
         };
 
         super::zcashd(config_dir.path(), 1234, &activation_heights, None).unwrap();
@@ -425,6 +426,7 @@ i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1";
             canopy: 5.into(),
             nu5: 6.into(),
             nu6: 7.into(),
+            nu6_1: 8.into(),
         };
 
         super::zcashd(

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -189,7 +189,7 @@ miner_address = \"{miner_address}\"
 Canopy = 1
 NU5 = {nu5_activation_height}
 NU6 = {nu6_activation_height}
-NU6.1 = {nu6_1_activation_height}"
+\"NU6.1\" = {nu6_1_activation_height}"
             )
             .as_bytes(),
         )?;
@@ -373,6 +373,7 @@ nuparams=f5b9230b:4 # Heartwood
 nuparams=e9ff75a6:5 # Canopy
 nuparams=c2d6d0b4:6 # NU5 (Orchard)
 nuparams=c8e71055:7 # NU6
+nuparams=4dec4df0:8 # NU6.1
 
 ### MetaData Storage and Retrieval
 # txindex:

--- a/services/src/network.rs
+++ b/services/src/network.rs
@@ -44,6 +44,8 @@ pub struct ActivationHeights {
     pub nu5: BlockHeight,
     /// Nu6 network upgrade activation height
     pub nu6: BlockHeight,
+    /// Nu6_1 network upgrade activation height
+    pub nu6_1: BlockHeight,
 }
 
 impl Default for ActivationHeights {
@@ -56,6 +58,7 @@ impl Default for ActivationHeights {
             canopy: 1.into(),
             nu5: 1.into(),
             nu6: 1.into(),
+            nu6_1: 1.into(),
         }
     }
 }
@@ -71,6 +74,7 @@ impl ActivationHeights {
             NetworkUpgrade::Canopy => self.canopy,
             NetworkUpgrade::Nu5 => self.nu5,
             NetworkUpgrade::Nu6 => self.nu6,
+            NetworkUpgrade::Nu6_1 => self.nu6_1,
         }
     }
 }

--- a/testutils/tests/integration.rs
+++ b/testutils/tests/integration.rs
@@ -51,6 +51,7 @@ async fn launch_zcashd_custom_activation_heights() {
         canopy: 3.into(),
         nu5: 5.into(),
         nu6: 7.into(),
+        nu6_1: 9.into(),
     };
     let zcashd = Zcashd::launch(ZcashdConfig {
         zcashd_bin: ZCASHD_BIN,


### PR DESCRIPTION
Adds NU 6.1 support. This is necessary for https://github.com/zingolabs/zingolib/pull/1898.