### PR TITLE
Use zebra-chain NetworkType instead of bespoke enum Network

### DIFF
--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -7,7 +7,8 @@ use std::path::{Path, PathBuf};
 use portpicker::Port;
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 
-use crate::network::{ActivationHeights, Network};
+use crate::network::ActivationHeights;
+use zebra_chain::parameters::NetworkKind;
 
 /// Used in subtree roots tests in zaino_testutils.  Fix later.
 pub const ZCASHD_FILENAME: &str = "zcash.conf";
@@ -99,7 +100,7 @@ pub(crate) fn zebrad(
     indexer_listen_port: Port,
     activation_heights: &ActivationHeights,
     miner_address: &str,
-    network: Network,
+    network: NetworkKind,
 ) -> std::io::Result<PathBuf> {
     let config_file_path = config_dir.join(ZEBRAD_FILENAME);
     let mut config_file = File::create(config_file_path.clone())?;
@@ -178,7 +179,7 @@ use_journald = false"
         .as_bytes(),
     )?;
 
-    if matches!(network, Network::Regtest) {
+    if matches!(network, NetworkKind::Regtest) {
         config_file.write_all(
             format!(
                 "\n\n\
@@ -208,7 +209,7 @@ pub(crate) fn zainod(
     validator_cache_dir: PathBuf,
     listen_port: Port,
     validator_port: Port,
-    network: Network,
+    network: NetworkKind,
 ) -> std::io::Result<PathBuf> {
     let config_file_path = config_dir.join(ZAINOD_FILENAME);
     let mut config_file = File::create(config_file_path.clone())?;
@@ -299,7 +300,7 @@ db_path = \"{chain_cache}\"
 
 
 
-# Network:
+# NetworkKind:
 
 # Network chain type (Mainnet, Testnet, Regtest).
 network = \"{network_string}\"
@@ -451,7 +452,7 @@ minetolocalwallet=0 # This is set to false so that we can mine to a wallet, othe
             zaino_cache_dir,
             1234,
             18232,
-            network::Network::Regtest,
+            network::NetworkKind::Regtest,
         )
         .unwrap();
 

--- a/services/src/indexer.rs
+++ b/services/src/indexer.rs
@@ -9,11 +9,13 @@ use getset::{CopyGetters, Getters};
 use portpicker::Port;
 use tempfile::TempDir;
 
+use zebra_chain::parameters::NetworkKind;
+
 use crate::{
     config,
     error::LaunchError,
     launch, logs,
-    network::{self, Network},
+    network::{self},
     utils::ExecutableLocation,
     Process,
 };
@@ -35,7 +37,7 @@ pub struct ZainodConfig {
     /// Chain cache path
     pub chain_cache: Option<PathBuf>,
     /// Network type.
-    pub network: Network,
+    pub network: NetworkKind,
 }
 
 impl ZainodConfig {
@@ -51,7 +53,7 @@ impl ZainodConfig {
             listen_port: None,
             validator_port: 0,
             chain_cache: None,
-            network: network::Network::Regtest,
+            network: NetworkKind::Regtest,
         }
     }
 }

--- a/services/src/network.rs
+++ b/services/src/network.rs
@@ -6,26 +6,7 @@ use zcash_protocol::consensus::{NetworkUpgrade, Parameters as _};
 
 pub(crate) const LOCALHOST_IPV4: &str = "http://127.0.0.1";
 
-/// Network types
-#[derive(Clone, Copy)]
-pub enum Network {
-    /// Regtest
-    Regtest,
-    /// Testnet
-    Testnet,
-    /// Mainnet
-    Mainnet,
-}
-
-impl std::fmt::Display for Network {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Mainnet => write!(f, "Mainnet"),
-            Self::Testnet => write!(f, "Testnet"),
-            Self::Regtest => write!(f, "Regtest"),
-        }
-    }
-}
+use zebra_chain::parameters::NetworkKind;
 
 /// Activation heights for local network upgrades
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/services/src/validator.rs
+++ b/services/src/validator.rs
@@ -10,6 +10,7 @@ use zcash_protocol::consensus::BlockHeight;
 use getset::{CopyGetters, Getters};
 use portpicker::Port;
 use tempfile::TempDir;
+use zebra_chain::parameters::NetworkKind;
 use zebra_chain::{
     parameters::testnet::ConfiguredActivationHeights, serialization::ZcashSerialize as _,
 };
@@ -23,7 +24,7 @@ use crate::{
     config,
     error::LaunchError,
     launch, logs,
-    network::{self, ActivationHeights, Network},
+    network::{self, ActivationHeights},
     utils::ExecutableLocation,
     Process,
 };
@@ -122,7 +123,7 @@ pub struct ZebradConfig {
     /// Chain cache path
     pub chain_cache: Option<PathBuf>,
     /// Network type
-    pub network: Network,
+    pub network: NetworkKind,
 }
 
 impl ZebradConfig {
@@ -141,7 +142,7 @@ impl ZebradConfig {
             activation_heights: network::ActivationHeights::default(),
             miner_address: ZEBRAD_DEFAULT_MINER,
             chain_cache: None,
-            network: Network::Regtest,
+            network: NetworkKind::Regtest,
         }
     }
 }
@@ -199,7 +200,7 @@ pub trait Validator: Sized {
     }
 
     /// Network type
-    fn network(&self) -> Network;
+    fn network(&self) -> NetworkKind;
 
     /// Caches chain. This stops the zcashd process.
     fn cache_chain(&mut self, chain_cache: PathBuf) -> std::process::Output {
@@ -226,7 +227,7 @@ pub trait Validator: Sized {
     fn load_chain(
         chain_cache: PathBuf,
         validator_data_dir: PathBuf,
-        validator_network: Network,
+        validator_network: NetworkKind,
     ) -> PathBuf;
 
     /// Prints the stdout log.
@@ -300,7 +301,7 @@ impl Validator for Zcashd {
         let data_dir = tempfile::tempdir().unwrap();
 
         if let Some(cache) = config.chain_cache.clone() {
-            Self::load_chain(cache, data_dir.path().to_path_buf(), Network::Regtest);
+            Self::load_chain(cache, data_dir.path().to_path_buf(), NetworkKind::Regtest);
         }
 
         let port = network::pick_unused_port(config.rpc_listen_port);
@@ -438,14 +439,14 @@ Error: {err}",
         &self.data_dir
     }
 
-    fn network(&self) -> Network {
+    fn network(&self) -> NetworkKind {
         unimplemented!();
     }
 
     fn load_chain(
         chain_cache: PathBuf,
         validator_data_dir: PathBuf,
-        _validator_network: Network,
+        _validator_network: NetworkKind,
     ) -> PathBuf {
         let regtest_dir = chain_cache.clone().join("regtest");
         if !regtest_dir.exists() {
@@ -494,7 +495,7 @@ pub struct Zebrad {
     /// RPC request client
     client: RpcRequestClient,
     /// Network type
-    network: Network,
+    network: NetworkKind,
 }
 
 impl Validator for Zebrad {
@@ -511,7 +512,7 @@ impl Validator for Zebrad {
         let logs_dir = tempfile::tempdir().unwrap();
         let data_dir = tempfile::tempdir().unwrap();
 
-        if !matches!(config.network, Network::Regtest) && config.chain_cache.is_none() {
+        if !matches!(config.network, NetworkKind::Regtest) && config.chain_cache.is_none() {
             panic!("chain cache must be specified when not using a regtest network!")
         }
 
@@ -619,7 +620,7 @@ Error: {err}",
             network: config.network,
         };
 
-        if config.chain_cache.is_none() && matches!(config.network, Network::Regtest) {
+        if config.chain_cache.is_none() && matches!(config.network, NetworkKind::Regtest) {
             // generate genesis block
             zebrad.generate_blocks(1).await.unwrap();
         }
@@ -724,21 +725,21 @@ Error: {err}",
         &self.data_dir
     }
 
-    fn network(&self) -> Network {
+    fn network(&self) -> NetworkKind {
         self.network
     }
 
     fn load_chain(
         chain_cache: PathBuf,
         validator_data_dir: PathBuf,
-        validator_network: Network,
+        validator_network: NetworkKind,
     ) -> PathBuf {
         let state_dir = chain_cache.clone().join("state");
         if !state_dir.exists() {
             panic!("state directory not found!");
         }
 
-        if matches!(validator_network, Network::Regtest) {
+        if matches!(validator_network, NetworkKind::Regtest) {
             std::process::Command::new("cp")
                 .arg("-r")
                 .arg(state_dir)


### PR DESCRIPTION
A step toward reducing an extra dependency.