### PR TITLE
Add default_test_config method to Validator and Indexer traits

### DIFF
--- a/services/src/indexer.rs
+++ b/services/src/indexer.rs
@@ -107,7 +107,7 @@ pub trait Indexer: Sized {
     /// Indexer config struct
     type Config;
 
-    /// generate a default test config
+    /// Generate a default test config
     fn default_test_config() -> Self::Config;
 
     /// Indexer listen port
@@ -174,7 +174,7 @@ impl Indexer for Zainod {
         self.port
     }
 
-    /// generate a default test config
+    /// Generate a default test config
     fn default_test_config() -> Self::Config {
         ZainodConfig::default_test()
     }
@@ -417,7 +417,8 @@ impl Indexer for Empty {
     fn listen_port(&self) -> Port {
         0
     }
-    /// generate a default test config
+
+    /// Generate a default test config
     fn default_test_config() -> Self::Config {
         EmptyConfig {}
     }

--- a/services/src/indexer.rs
+++ b/services/src/indexer.rs
@@ -107,6 +107,9 @@ pub trait Indexer: Sized {
     /// Indexer config struct
     type Config;
 
+    /// generate a default test config
+    fn default_test_config() -> Self::Config;
+
     /// Indexer listen port
     fn listen_port(&self) -> Port;
 
@@ -169,6 +172,11 @@ impl Indexer for Zainod {
 
     fn listen_port(&self) -> Port {
         self.port
+    }
+
+    /// generate a default test config
+    fn default_test_config() -> Self::Config {
+        ZainodConfig::default_test()
     }
 
     fn launch(config: Self::Config) -> Result<Self, LaunchError> {
@@ -291,6 +299,11 @@ impl Indexer for Lightwalletd {
         self.port
     }
 
+    /// generate a default test config
+    fn default_test_config() -> Self::Config {
+        LightwalletdConfig::default_test()
+    }
+
     fn launch(config: Self::Config) -> Result<Self, LaunchError> {
         let logs_dir = tempfile::tempdir().unwrap();
         let lwd_log_file_path = logs_dir.path().join(logs::LIGHTWALLETD_LOG);
@@ -403,6 +416,10 @@ impl Indexer for Empty {
 
     fn listen_port(&self) -> Port {
         0
+    }
+    /// generate a default test config
+    fn default_test_config() -> Self::Config {
+        EmptyConfig {}
     }
 
     fn launch(_config: Self::Config) -> Result<Self, LaunchError> {

--- a/services/src/validator.rs
+++ b/services/src/validator.rs
@@ -161,6 +161,9 @@ pub trait Validator: Sized {
     /// Return activation heights
     fn activation_heights(&self) -> ActivationHeights;
 
+    /// generate a default test config
+    fn default_test_config() -> Self::Config;
+
     /// Launch the process.
     fn launch(
         config: Self::Config,
@@ -294,6 +297,11 @@ impl Validator for Zcashd {
 
     fn activation_heights(&self) -> ActivationHeights {
         self.activation_heights
+    }
+
+    /// generate a default test config
+    fn default_test_config() -> Self::Config {
+        ZcashdConfig::default_test()
     }
 
     async fn launch(config: Self::Config) -> Result<Self, LaunchError> {
@@ -506,6 +514,11 @@ impl Validator for Zebrad {
 
     fn activation_heights(&self) -> ActivationHeights {
         self.activation_heights
+    }
+
+    /// generate a default test config
+    fn default_test_config() -> Self::Config {
+        ZebradConfig::default_test()
     }
 
     async fn launch(config: Self::Config) -> Result<Self, LaunchError> {


### PR DESCRIPTION
It provides an easy way to instantiate a complex type. Plug and play tests are unlocked.