### PR TITLE
zcash_protocol::local_network is a common type for heights

### DIFF
--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -562,10 +562,10 @@ db_path = \"{zaino_test_path}\"
 
 
 
-# Network:
+# NetworkKind:
 
 # Network chain type (Mainnet, Testnet, Regtest).
-network = \"Regtest\"
+network = \"RegtestKind\"
 
 
 

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -331,7 +331,7 @@ db_path = \"{chain_cache}\"
 
 
 
-# NetworkKind:
+# Network:
 
 # Network chain type (Mainnet, Testnet, Regtest).
 network = \"{network_string}\"
@@ -571,7 +571,7 @@ db_path = \"{zaino_test_path}\"
 
 
 
-# NetworkKind:
+# Network:
 
 # Network chain type (Mainnet, Testnet, Regtest).
 network = \"Regtest\"

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -10,6 +10,15 @@ use zcash_protocol::consensus::{BlockHeight, Parameters};
 use zcash_protocol::local_consensus::LocalNetwork;
 use zebra_chain::parameters::NetworkKind;
 
+/// Convert NetworkKind to its config string representation
+fn network_kind_to_string(network: NetworkKind) -> &'static str {
+    match network {
+        NetworkKind::Mainnet => "Mainnet",
+        NetworkKind::Testnet => "Testnet",
+        NetworkKind::Regtest => "Regtest",
+    }
+}
+
 /// Used in subtree roots tests in zaino_testutils.  Fix later.
 pub const ZCASHD_FILENAME: &str = "zcash.conf";
 pub(crate) const ZEBRAD_FILENAME: &str = "zebrad.toml";
@@ -137,7 +146,7 @@ pub(crate) fn zebrad(
 
     let chain_cache = cache_dir.to_str().unwrap();
 
-    let network_string = network.to_string();
+    let network_string = network_kind_to_string(network);
 
     config_file.write_all(
         format!(
@@ -239,7 +248,7 @@ pub(crate) fn zainod(
     let zaino_cache_dir = validator_cache_dir.join("zaino");
     let chain_cache = zaino_cache_dir.to_str().unwrap();
 
-    let network_string = network.to_string();
+    let network_string = network_kind_to_string(network);
 
     config_file.write_all(
         format!(
@@ -565,7 +574,7 @@ db_path = \"{zaino_test_path}\"
 # NetworkKind:
 
 # Network chain type (Mainnet, Testnet, Regtest).
-network = \"RegtestKind\"
+network = \"Regtest\"
 
 
 

--- a/services/src/config.rs
+++ b/services/src/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use portpicker::Port;
 use zcash_protocol::consensus::{BlockHeight, Parameters};
 
-use crate::network::ActivationHeights;
+use zcash_protocol::local_consensus::LocalNetwork;
 use zebra_chain::parameters::NetworkKind;
 
 /// Used in subtree roots tests in zaino_testutils.  Fix later.
@@ -22,7 +22,7 @@ use zcash_protocol::consensus::NetworkUpgrade;
 pub(crate) fn zcashd(
     config_dir: &Path,
     rpc_port: Port,
-    activation_heights: &ActivationHeights,
+    activation_heights: &LocalNetwork,
     miner_address: Option<&str>,
 ) -> std::io::Result<PathBuf> {
     let config_file_path = config_dir.join(ZCASHD_FILENAME);
@@ -114,7 +114,7 @@ pub(crate) fn zebrad(
     network_listen_port: Port,
     rpc_listen_port: Port,
     indexer_listen_port: Port,
-    activation_heights: &ActivationHeights,
+    activation_heights: &LocalNetwork,
     miner_address: &str,
     network: NetworkKind,
 ) -> std::io::Result<PathBuf> {
@@ -389,7 +389,7 @@ mod tests {
 
     use zebra_chain::parameters::NetworkKind;
 
-    use crate::{logs, network};
+    use crate::{logs, validator::sequential_regtest_heights};
 
     const EXPECTED_CONFIG: &str = "\
 ### Blockchain Configuration
@@ -429,7 +429,7 @@ i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1";
     #[test]
     fn zcashd() {
         let config_dir = tempfile::tempdir().unwrap();
-        let activation_heights = network::ActivationHeights::sequential_heights();
+        let activation_heights = sequential_regtest_heights();
 
         super::zcashd(config_dir.path(), 1234, &activation_heights, None).unwrap();
 
@@ -442,7 +442,7 @@ i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1";
     #[test]
     fn zcashd_funded() {
         let config_dir = tempfile::tempdir().unwrap();
-        let activation_heights = network::ActivationHeights::sequential_heights();
+        let activation_heights = sequential_regtest_heights();
 
         super::zcashd(
             config_dir.path(),

--- a/services/src/network.rs
+++ b/services/src/network.rs
@@ -1,71 +1,8 @@
 //! Structs and utility functions associated with local network configuration
 
 use portpicker::Port;
-use zcash_primitives::consensus::BlockHeight;
-use zcash_protocol::consensus::NetworkUpgrade;
 
 pub(crate) const LOCALHOST_IPV4: &str = "http://127.0.0.1";
-
-/// Activation heights for local network upgrades
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ActivationHeights {
-    inner: zcash_protocol::local_consensus::LocalNetwork,
-}
-
-impl Default for ActivationHeights {
-    fn default() -> Self {
-        Self {
-            inner: zcash_protocol::local_consensus::LocalNetwork {
-                overwinter: Some(BlockHeight::from(1)),
-                sapling: Some(BlockHeight::from(1)),
-                blossom: Some(BlockHeight::from(1)),
-                heartwood: Some(BlockHeight::from(1)),
-                canopy: Some(BlockHeight::from(1)),
-                nu5: Some(BlockHeight::from(1)),
-                nu6: Some(BlockHeight::from(1)),
-                nu6_1: Some(BlockHeight::from(1)),
-            },
-        }
-    }
-}
-
-impl ActivationHeights {
-    /// Returns activation height for given `network_upgrade`.
-    pub fn new(inner: zcash_protocol::local_consensus::LocalNetwork) -> Self {
-        Self { inner }
-    }
-
-    /// Returns wrapped [`zcash_protocol::local_consensus::LocalNetwork`].
-    pub fn inner(&self) -> zcash_protocol::local_consensus::LocalNetwork {
-        self.inner
-    }
-
-    /// Creates activation heights with sequential block heights (1, 2, 3, 4, 5, 6, 7, 8)
-    pub fn sequential_heights() -> Self {
-        Self {
-            inner: zcash_protocol::local_consensus::LocalNetwork {
-                overwinter: Some(BlockHeight::from(1)),
-                sapling: Some(BlockHeight::from(2)),
-                blossom: Some(BlockHeight::from(3)),
-                heartwood: Some(BlockHeight::from(4)),
-                canopy: Some(BlockHeight::from(5)),
-                nu5: Some(BlockHeight::from(6)),
-                nu6: Some(BlockHeight::from(7)),
-                nu6_1: Some(BlockHeight::from(8)),
-            },
-        }
-    }
-}
-
-impl zcash_protocol::consensus::Parameters for ActivationHeights {
-    fn network_type(&self) -> zcash_protocol::consensus::NetworkType {
-        self.inner.network_type()
-    }
-
-    fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
-        self.inner.activation_height(nu)
-    }
-}
 
 /// Checks `fixed_port` is not in use.
 /// If `fixed_port` is `None`, returns a random free port between 15_000 and 25_000.

--- a/services/src/validator.rs
+++ b/services/src/validator.rs
@@ -21,13 +21,36 @@ use zebra_rpc::{
 };
 
 use crate::{
-    config,
-    error::LaunchError,
-    launch, logs,
-    network::{self, ActivationHeights},
-    utils::ExecutableLocation,
-    Process,
+    config, error::LaunchError, launch, logs, network, utils::ExecutableLocation, Process,
 };
+
+/// Returns a LocalNetwork with all upgrades activated at height 1
+pub fn default_regtest_heights() -> zcash_protocol::local_consensus::LocalNetwork {
+    zcash_protocol::local_consensus::LocalNetwork {
+        overwinter: Some(BlockHeight::from(1)),
+        sapling: Some(BlockHeight::from(1)),
+        blossom: Some(BlockHeight::from(1)),
+        heartwood: Some(BlockHeight::from(1)),
+        canopy: Some(BlockHeight::from(1)),
+        nu5: Some(BlockHeight::from(1)),
+        nu6: Some(BlockHeight::from(1)),
+        nu6_1: Some(BlockHeight::from(1)),
+    }
+}
+
+/// Returns a LocalNetwork with sequential activation heights (1, 2, 3, 4, 5, 6, 7, 8)
+pub fn sequential_regtest_heights() -> zcash_protocol::local_consensus::LocalNetwork {
+    zcash_protocol::local_consensus::LocalNetwork {
+        overwinter: Some(BlockHeight::from(1)),
+        sapling: Some(BlockHeight::from(2)),
+        blossom: Some(BlockHeight::from(3)),
+        heartwood: Some(BlockHeight::from(4)),
+        canopy: Some(BlockHeight::from(5)),
+        nu5: Some(BlockHeight::from(6)),
+        nu6: Some(BlockHeight::from(7)),
+        nu6_1: Some(BlockHeight::from(8)),
+    }
+}
 
 /// faucet addresses
 /// this should be in a test-vectors crate. However, in order to distangle this knot, a cut and paste in merited here -fv
@@ -61,7 +84,7 @@ pub struct ZcashdConfig {
     /// Zcashd RPC listen port
     pub rpc_listen_port: Option<Port>,
     /// Local network upgrade activation heights
-    pub activation_heights: network::ActivationHeights,
+    pub activation_heights: zcash_protocol::local_consensus::LocalNetwork,
     /// Miner address
     pub miner_address: Option<&'static str>,
     /// Chain cache path
@@ -85,7 +108,7 @@ impl ZcashdConfig {
             zcashd_bin: Self::default_location(),
             zcash_cli_bin: Self::default_cli_location(),
             rpc_listen_port: None,
-            activation_heights: network::ActivationHeights::default(),
+            activation_heights: default_regtest_heights(),
             miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
             chain_cache: None,
         }
@@ -117,7 +140,7 @@ pub struct ZebradConfig {
     /// Zebrad gRPC listen port
     pub indexer_listen_port: Option<Port>,
     /// Local network upgrade activation heights
-    pub activation_heights: network::ActivationHeights,
+    pub activation_heights: zcash_protocol::local_consensus::LocalNetwork,
     /// Miner address
     pub miner_address: &'static str,
     /// Chain cache path
@@ -139,7 +162,7 @@ impl ZebradConfig {
             network_listen_port: None,
             rpc_listen_port: None,
             indexer_listen_port: None,
-            activation_heights: network::ActivationHeights::default(),
+            activation_heights: default_regtest_heights(),
             miner_address: ZEBRAD_DEFAULT_MINER,
             chain_cache: None,
             network: NetworkKind::Regtest,
@@ -159,7 +182,7 @@ pub trait Validator: Sized {
     type Config;
 
     /// Return activation heights
-    fn activation_heights(&self) -> ActivationHeights;
+    fn activation_heights(&self) -> zcash_protocol::local_consensus::LocalNetwork;
 
     /// Launch the process.
     fn launch(
@@ -268,7 +291,7 @@ pub struct Zcashd {
     zcash_cli_bin: ExecutableLocation,
     /// Network upgrade activation heights
     #[getset(skip)]
-    activation_heights: network::ActivationHeights,
+    activation_heights: zcash_protocol::local_consensus::LocalNetwork,
 }
 
 impl Zcashd {
@@ -292,7 +315,7 @@ impl Validator for Zcashd {
 
     type Config = ZcashdConfig;
 
-    fn activation_heights(&self) -> ActivationHeights {
+    fn activation_heights(&self) -> zcash_protocol::local_consensus::LocalNetwork {
         self.activation_heights
     }
 
@@ -491,7 +514,7 @@ pub struct Zebrad {
     data_dir: TempDir,
     /// Network upgrade activation heights
     #[getset(skip)]
-    activation_heights: network::ActivationHeights,
+    activation_heights: zcash_protocol::local_consensus::LocalNetwork,
     /// RPC request client
     client: RpcRequestClient,
     /// Network type
@@ -504,7 +527,7 @@ impl Validator for Zebrad {
 
     type Config = ZebradConfig;
 
-    fn activation_heights(&self) -> ActivationHeights {
+    fn activation_heights(&self) -> zcash_protocol::local_consensus::LocalNetwork {
         self.activation_heights
     }
 

--- a/services/tests/integration.rs
+++ b/services/tests/integration.rs
@@ -3,7 +3,6 @@ mod testutils;
 use zcash_protocol::consensus::BlockHeight;
 use zingo_infra_services::{
     indexer::{Indexer, Lightwalletd, LightwalletdConfig, Zainod, ZainodConfig},
-    network::ActivationHeights,
     utils,
     validator::{Validator, Zcashd, ZcashdConfig, Zebrad, ZebradConfig},
     LocalNet,
@@ -23,17 +22,16 @@ async fn launch_zcashd() {
 async fn launch_zcashd_custom_activation_heights() {
     tracing_subscriber::fmt().init();
 
-    let activation_heights =
-        ActivationHeights::new(zcash_protocol::local_consensus::LocalNetwork {
-            overwinter: Some(BlockHeight::from(1)),
-            sapling: Some(BlockHeight::from(1)),
-            blossom: Some(BlockHeight::from(1)),
-            heartwood: Some(BlockHeight::from(1)),
-            canopy: Some(BlockHeight::from(3)),
-            nu5: Some(BlockHeight::from(5)),
-            nu6: Some(BlockHeight::from(7)),
-            nu6_1: Some(BlockHeight::from(9)),
-        });
+    let activation_heights = zcash_protocol::local_consensus::LocalNetwork {
+        overwinter: Some(BlockHeight::from(1)),
+        sapling: Some(BlockHeight::from(1)),
+        blossom: Some(BlockHeight::from(1)),
+        heartwood: Some(BlockHeight::from(1)),
+        canopy: Some(BlockHeight::from(3)),
+        nu5: Some(BlockHeight::from(5)),
+        nu6: Some(BlockHeight::from(7)),
+        nu6_1: Some(BlockHeight::from(9)),
+    };
     let mut config = ZcashdConfig::default_test();
     config.activation_heights = activation_heights;
     let zcashd = Zcashd::launch(config).await.unwrap();

--- a/services/tests/testutils.rs
+++ b/services/tests/testutils.rs
@@ -27,9 +27,10 @@ use std::path::PathBuf;
 use zebra_chain::parameters::NetworkKind;
 use zingo_infra_services::{
     indexer::{Lightwalletd, LightwalletdConfig},
-    network,
     utils::{self, ExecutableLocation},
-    validator::{Validator as _, Zebrad, ZebradConfig, ZEBRAD_DEFAULT_MINER},
+    validator::{
+        default_regtest_heights, Validator as _, Zebrad, ZebradConfig, ZEBRAD_DEFAULT_MINER,
+    },
     LocalNet,
 };
 /// Generates zebrad chain cache for client RPC test fixtures requiring a large chain
@@ -49,7 +50,7 @@ pub async fn generate_zebrad_large_chain_cache(
             network_listen_port: None,
             rpc_listen_port: None,
             indexer_listen_port: None,
-            activation_heights: network::ActivationHeights::default(),
+            activation_heights: default_regtest_heights(),
             miner_address: ZEBRAD_DEFAULT_MINER,
             chain_cache: None,
             network: NetworkKind::Regtest,
@@ -87,7 +88,7 @@ pub async fn generate_zcashd_chain_cache(
     //         zcashd_bin,
     //         zcash_cli_bin,
     //         rpc_listen_port: None,
-    //         activation_heights: network::ActivationHeights::default(),
+    //         activation_heights: default_regtest_heights(),
     //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
     //         chain_cache: None,
     //     },
@@ -227,7 +228,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -336,7 +337,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -407,7 +408,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -477,7 +478,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -543,7 +544,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -621,7 +622,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -713,7 +714,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -805,7 +806,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -897,7 +898,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -988,7 +989,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1080,7 +1081,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1197,7 +1198,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1294,7 +1295,7 @@ pub async fn generate_zcashd_chain_cache(
 //             zcashd_bin: zcashd_bin.clone(),
 //             zcash_cli_bin: zcash_cli_bin.clone(),
 //             rpc_listen_port: None,
-//             activation_heights: network::ActivationHeights::default(),
+//             activation_heights: default_regtest_heights(),
 //             miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //             chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //         },
@@ -1356,7 +1357,7 @@ pub async fn generate_zcashd_chain_cache(
 //             zcashd_bin,
 //             zcash_cli_bin,
 //             rpc_listen_port: None,
-//             activation_heights: network::ActivationHeights::default(),
+//             activation_heights: default_regtest_heights(),
 //             miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //             chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //         },
@@ -1438,7 +1439,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1555,7 +1556,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1672,7 +1673,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1789,7 +1790,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1865,7 +1866,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -1943,7 +1944,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2092,7 +2093,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2290,7 +2291,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2646,7 +2647,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2719,7 +2720,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2802,7 +2803,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2875,7 +2876,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -2963,7 +2964,7 @@ pub async fn generate_zcashd_chain_cache(
 //         network_listen_port: None,
 //         rpc_listen_port: None,
 //         indexer_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: ZEBRAD_DEFAULT_MINER,
 //         chain_cache: Some(utils::chain_cache_dir().join("get_subtree_roots_sapling")),
 //         network,
@@ -3068,7 +3069,7 @@ pub async fn generate_zcashd_chain_cache(
 //         network_listen_port: None,
 //         rpc_listen_port: None,
 //         indexer_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: ZEBRAD_DEFAULT_MINER,
 //         chain_cache: Some(utils::chain_cache_dir().join("get_subtree_roots_orchard")),
 //         network,
@@ -3152,7 +3153,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3230,7 +3231,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3309,7 +3310,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3388,7 +3389,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3466,7 +3467,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3552,7 +3553,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3639,7 +3640,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })
@@ -3726,7 +3727,7 @@ pub async fn generate_zcashd_chain_cache(
 //         zcashd_bin,
 //         zcash_cli_bin,
 //         rpc_listen_port: None,
-//         activation_heights: network::ActivationHeights::default(),
+//         activation_heights: default_regtest_heights(),
 //         miner_address: Some(REG_O_ADDR_FROM_ABANDONART),
 //         chain_cache: Some(utils::chain_cache_dir().join("client_rpc_tests")),
 //     })


### PR DESCRIPTION
This PR prefers it in this repo.

Thanks to @fluidvanadium for the suggestion.