### PR TITLE
fix: re-export type necessary for `set_test_parameters`

### DIFF
--- a/zcash_local_net/src/lib.rs
+++ b/zcash_local_net/src/lib.rs
@@ -47,6 +47,8 @@ use crate::{
     error::LaunchError, indexer::IndexerConfig, logs::LogsToStdoutAndStderr, process::Process,
 };
 
+pub use zcash_protocol::PoolType;
+
 /// All processes currently supported
 #[derive(Clone, Copy)]
 #[allow(missing_docs)]


### PR DESCRIPTION
This PR re-exports a type that is necessary for using `set_test_parameters` without having to match the same `zcash_protocol` crate version.