### PR TITLE
begin working backwards from config file clarifying names

### DIFF
--- a/zcash_local_net/src/config.rs
+++ b/zcash_local_net/src/config.rs
@@ -513,7 +513,7 @@ grpc_tls = false
 
 # Full node / validator listen address.
 #
-# Must be a \"pravate\" address as defined in [IETF RFC 1918] for ipv4 addreses and [IETF RFC 4193] for ipv6 addreses.
+# Must be a \"private\" address as defined in [IETF RFC 1918] for ipv4 addreses and [IETF RFC 4193] for ipv6 addreses.
 #
 # Must use validator rpc cookie authentication when connecting to non localhost addresses.
 validator_listen_address = \"localhost:18232\"

--- a/zcash_local_net/src/config.rs
+++ b/zcash_local_net/src/config.rs
@@ -231,8 +231,8 @@ NU6 = {nu6_activation_height}
 pub(crate) fn write_zainod_config(
     config_dir: &Path,
     validator_cache_dir: PathBuf,
-    listen_port: Port,
-    validator_port: Port,
+    zainod_grpc_control_port: Port,
+    validator_rpc_control_port: Port,
     network: NetworkKind,
 ) -> std::io::Result<PathBuf> {
     let config_file_path = config_dir.join(ZAINOD_FILENAME);
@@ -253,7 +253,7 @@ pub(crate) fn write_zainod_config(
 # Zainod's gRPC server listen address.
 #
 # Must use TLS when connecting to non localhost addresses.
-grpc_listen_address = \"localhost:{listen_port}\"
+grpc_listen_address = \"localhost:{zainod_grpc_control_port}\"
 
 # Enables TLS for the gRPC server.
 grpc_tls = false
@@ -272,10 +272,10 @@ grpc_tls = false
 
 # Full node / validator listen address.
 #
-# Must be a \"pravate\" address as defined in [IETF RFC 1918] for ipv4 addreses and [IETF RFC 4193] for ipv6 addreses.
+# Must be a \"private\" address as defined in [IETF RFC 1918] for ipv4 addreses and [IETF RFC 4193] for ipv6 addreses.
 #
 # Must use validator rpc cookie authentication when connecting to non localhost addresses.
-validator_listen_address = \"localhost:{validator_port}\"
+validator_listen_address = \"localhost:{validator_rpc_control_port}\"
 
 # Enable validator rpc cookie authentication.
 validator_cookie_auth = false

--- a/zcash_local_net/src/config.rs
+++ b/zcash_local_net/src/config.rs
@@ -231,7 +231,7 @@ NU6 = {nu6_activation_height}
 pub(crate) fn write_zainod_config(
     config_dir: &Path,
     validator_cache_dir: PathBuf,
-    zainod_grpc_control_port: Port,
+    grpc_listen_port: Port,
     validator_rpc_control_port: Port,
     network: NetworkKind,
 ) -> std::io::Result<PathBuf> {
@@ -253,7 +253,7 @@ pub(crate) fn write_zainod_config(
 # Zainod's gRPC server listen address.
 #
 # Must use TLS when connecting to non localhost addresses.
-grpc_listen_address = \"localhost:{zainod_grpc_control_port}\"
+grpc_listen_address = \"localhost:{grpc_listen_port}\"
 
 # Enables TLS for the gRPC server.
 grpc_tls = false

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -32,7 +32,7 @@ use crate::{
 #[derive(Debug)]
 pub struct ZainodConfig {
     /// Listen RPC port
-    pub listen_port: Option<Port>,
+    pub g_rpc_listen_port: Option<Port>,
     /// Validator RPC port
     pub validator_rpc_control_port: Port,
     /// Chain cache path
@@ -44,7 +44,7 @@ pub struct ZainodConfig {
 impl Default for ZainodConfig {
     fn default() -> Self {
         ZainodConfig {
-            listen_port: None,
+            g_rpc_listen_port: None,
             validator_rpc_control_port: 0,
             chain_cache: None,
             network: NetworkKind::Regtest,
@@ -58,7 +58,7 @@ impl IndexerConfig for ZainodConfig {
     }
 
     fn set_listen_port(&mut self, indexer_listen_port: Option<Port>) {
-        self.listen_port = indexer_listen_port;
+        self.g_rpc_listen_port = indexer_listen_port;
     }
 }
 
@@ -93,7 +93,8 @@ impl Process for Zainod {
         let logs_dir = tempfile::tempdir().unwrap();
         let data_dir = tempfile::tempdir().unwrap();
 
-        let zainod_grpc_control_port = network::pick_unused_port(config.listen_port);
+        dbg!(&config);
+        let grpc_listen_port = network::pick_unused_port(config.g_rpc_listen_port);
         let config_dir = tempfile::tempdir().unwrap();
 
         let cache_dir = if let Some(cache) = config.chain_cache.clone() {
@@ -105,7 +106,7 @@ impl Process for Zainod {
         let config_file_path = config::write_zainod_config(
             config_dir.path(),
             cache_dir,
-            zainod_grpc_control_port,
+            grpc_listen_port,
             config.validator_rpc_control_port,
             config.network,
         )
@@ -122,6 +123,7 @@ impl Process for Zainod {
 
         let mut handle = command.spawn().expect(EXPECT_SPAWN);
         logs::write_logs(&mut handle, &logs_dir);
+        dbg!("About to launch!");
         launch::wait(
             ProcessId::Zainod,
             &mut handle,
@@ -134,7 +136,7 @@ impl Process for Zainod {
 
         Ok(Zainod {
             handle,
-            port: zainod_grpc_control_port,
+            port: grpc_listen_port,
             logs_dir,
             config_dir,
         })

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -34,7 +34,7 @@ pub struct ZainodConfig {
     /// Listen RPC port
     pub listen_port: Option<Port>,
     /// Validator RPC port
-    pub validator_port: Port,
+    pub validator_rpc_control_port: Port,
     /// Chain cache path
     pub chain_cache: Option<PathBuf>,
     /// Network type.
@@ -45,7 +45,7 @@ impl Default for ZainodConfig {
     fn default() -> Self {
         ZainodConfig {
             listen_port: None,
-            validator_port: 0,
+            validator_rpc_control_port: 0,
             chain_cache: None,
             network: NetworkKind::Regtest,
         }
@@ -54,7 +54,7 @@ impl Default for ZainodConfig {
 
 impl IndexerConfig for ZainodConfig {
     fn setup_validator_connection<V: crate::validator::Validator>(&mut self, validator: &V) {
-        self.validator_port = validator.get_port();
+        self.validator_rpc_control_port = validator.get_port();
     }
 
     fn set_listen_port(&mut self, indexer_listen_port: Option<Port>) {
@@ -93,7 +93,7 @@ impl Process for Zainod {
         let logs_dir = tempfile::tempdir().unwrap();
         let data_dir = tempfile::tempdir().unwrap();
 
-        let port = network::pick_unused_port(config.listen_port);
+        let zainod_grpc_control_port = network::pick_unused_port(config.listen_port);
         let config_dir = tempfile::tempdir().unwrap();
 
         let cache_dir = if let Some(cache) = config.chain_cache.clone() {
@@ -105,8 +105,8 @@ impl Process for Zainod {
         let config_file_path = config::write_zainod_config(
             config_dir.path(),
             cache_dir,
-            port,
-            config.validator_port,
+            zainod_grpc_control_port,
+            config.validator_rpc_control_port,
             config.network,
         )
         .unwrap();
@@ -134,7 +134,7 @@ impl Process for Zainod {
 
         Ok(Zainod {
             handle,
-            port,
+            port: zainod_grpc_control_port,
             logs_dir,
             config_dir,
         })

--- a/zcash_local_net/src/lib.rs
+++ b/zcash_local_net/src/lib.rs
@@ -199,6 +199,8 @@ where
         } = config;
         let validator = <V as Process>::launch(validator_config).await?;
         indexer_config.setup_validator_connection(&validator);
+        dbg!(&validator);
+        dbg!(&indexer_config);
         let indexer = <I as Process>::launch(indexer_config).await?;
 
         Ok(LocalNet { indexer, validator })


### PR DESCRIPTION
* free from other context names should be as specific as possible, so zainod-* where the indexer must be zainod, e.g. in the config file for zainod.
* in zainod and other config names should include purpose and protocol e.g. controlplane_rpc-, or
p2p_grpc-
* in a given config which component (validator, indexer, client) purpose (control, p2p) and protocol (gRPC, RPC) is a appropriate, note that self is
implied in those cases