### PR TITLE
Executable finder polish

### DIFF
--- a/zcash_local_net/Cargo.toml
+++ b/zcash_local_net/Cargo.toml
@@ -34,8 +34,9 @@ json = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
 tokio = { workspace = true }
-tracing-subscriber = { workspace = true }
 
+[dev-dependencies]
+tracing-subscriber = { workspace = true }
 
 [build-dependencies]
 hex = { workspace = true }

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -12,7 +12,7 @@ use crate::{
     logs::{self, LogsToDir, LogsToStdoutAndStderr as _},
     network::{self},
     process::Process,
-    utils::executable_finder::{pick_command, EXPECT_SPAWN},
+    utils::executable_finder::{pick_command, trace_version, EXPECT_SPAWN},
     ProcessId,
 };
 
@@ -107,7 +107,7 @@ impl Process for Lightwalletd {
         .unwrap();
 
         let lightwalletd_executable_name = "lightwalletd";
-        logs::trace_version(lightwalletd_executable_name, "version");
+        trace_version(lightwalletd_executable_name, "version");
         let mut command = pick_command(lightwalletd_executable_name);
         let mut args = vec![
             "--no-tls-very-insecure",

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -12,7 +12,7 @@ use crate::{
     logs::{self, LogsToDir, LogsToStdoutAndStderr as _},
     network::{self},
     process::Process,
-    utils::executable_finder::{pick_command, trace_version, EXPECT_SPAWN},
+    utils::executable_finder::{pick_command, trace_version_and_location, EXPECT_SPAWN},
     ProcessId,
 };
 
@@ -107,8 +107,8 @@ impl Process for Lightwalletd {
         .unwrap();
 
         let lightwalletd_executable_name = "lightwalletd";
-        trace_version(lightwalletd_executable_name, "version");
-        let mut command = pick_command(lightwalletd_executable_name);
+        trace_version_and_location(lightwalletd_executable_name, "version");
+        let mut command = pick_command(lightwalletd_executable_name, false);
         let mut args = vec![
             "--no-tls-very-insecure",
             "--data-dir",

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -107,9 +107,7 @@ impl Process for Lightwalletd {
         .unwrap();
 
         let lightwalletd_executable_name = "lightwalletd";
-
         logs::trace_version(lightwalletd_executable_name, "version");
-
         let mut command = pick_command(lightwalletd_executable_name);
         let mut args = vec![
             "--no-tls-very-insecure",

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -107,6 +107,15 @@ impl Process for Lightwalletd {
         .unwrap();
 
         let mut command = pick_command("lightwalletd");
+
+        let mut args = vec!["version"];
+
+        command.args(args);
+
+        let version = command.output().expect(EXPECT_SPAWN);
+        tracing::info!("lightwalletd version {version:?}");
+
+        let mut command = pick_command("lightwalletd");
         let mut args = vec![
             "--no-tls-very-insecure",
             "--data-dir",

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -106,9 +106,11 @@ impl Process for Lightwalletd {
         )
         .unwrap();
 
-        logs::trace_version("lightwalletd", "version");
+        let lightwalletd_executable_name = "lightwalletd";
 
-        let mut command = pick_command("lightwalletd");
+        logs::trace_version(lightwalletd_executable_name, "version");
+
+        let mut command = pick_command(lightwalletd_executable_name);
         let mut args = vec![
             "--no-tls-very-insecure",
             "--data-dir",

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -106,14 +106,7 @@ impl Process for Lightwalletd {
         )
         .unwrap();
 
-        let mut command = pick_command("lightwalletd");
-
-        let mut args = vec!["version"];
-
-        command.args(args);
-
-        let version = command.output().expect(EXPECT_SPAWN);
-        tracing::info!("lightwalletd version {version:?}");
+        logs::trace_version("lightwalletd", "version");
 
         let mut command = pick_command("lightwalletd");
         let mut args = vec![

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -10,7 +10,7 @@ use zebra_chain::parameters::NetworkKind;
 
 use crate::logs::LogsToDir;
 use crate::logs::LogsToStdoutAndStderr as _;
-use crate::utils::executable_finder::trace_version;
+use crate::utils::executable_finder::trace_version_and_location;
 use crate::{
     config,
     error::LaunchError,
@@ -113,8 +113,8 @@ impl Process for Zainod {
         .unwrap();
 
         let executable_name = "zainod";
-        trace_version(executable_name, "--version");
-        let mut command = pick_command(executable_name);
+        trace_version_and_location(executable_name, "--version");
+        let mut command = pick_command(executable_name, false);
         command
             .args([
                 "--config",

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -10,6 +10,7 @@ use zebra_chain::parameters::NetworkKind;
 
 use crate::logs::LogsToDir;
 use crate::logs::LogsToStdoutAndStderr as _;
+use crate::utils::executable_finder::trace_version;
 use crate::{
     config,
     error::LaunchError,
@@ -112,7 +113,7 @@ impl Process for Zainod {
         .unwrap();
 
         let executable_name = "zainod";
-        logs::trace_version(executable_name, "--version");
+        trace_version(executable_name, "--version");
         let mut command = pick_command(executable_name);
         command
             .args([

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -111,7 +111,9 @@ impl Process for Zainod {
         )
         .unwrap();
 
-        let mut command = pick_command("zainod");
+        let executable_name = "zainod";
+        logs::trace_version(executable_name, "--version");
+        let mut command = pick_command(executable_name);
         command
             .args([
                 "--config",

--- a/zcash_local_net/src/logs.rs
+++ b/zcash_local_net/src/logs.rs
@@ -56,20 +56,3 @@ impl<T: LogsToDir> LogsToStdoutAndStderr for T {
         print_log(stdout_log_path);
     }
 }
-
-/// Helper to trace the executable version.
-pub fn trace_version(executable_name: &str, version_command: &str) {
-    let mut command = crate::utils::executable_finder::pick_command(executable_name);
-
-    let args = vec![version_command];
-
-    command.args(args);
-
-    let version = command
-        .output()
-        .expect(crate::utils::executable_finder::EXPECT_SPAWN);
-    tracing::info!(
-        "$ {executable_name} {version_command}
- {version:?}"
-    );
-}

--- a/zcash_local_net/src/logs.rs
+++ b/zcash_local_net/src/logs.rs
@@ -57,15 +57,19 @@ impl<T: LogsToDir> LogsToStdoutAndStderr for T {
     }
 }
 
+/// Helper to trace the executable version.
 pub fn trace_version(executable_name: &str, version_command: &str) {
     let mut command = crate::utils::executable_finder::pick_command(executable_name);
 
-    let mut args = vec![version_command];
+    let args = vec![version_command];
 
     command.args(args);
 
     let version = command
         .output()
         .expect(crate::utils::executable_finder::EXPECT_SPAWN);
-    tracing::info!("lightwalletd version {version:?}");
+    tracing::info!(
+        "$ {executable_name} {version_command}
+ {version:?}"
+    );
 }

--- a/zcash_local_net/src/logs.rs
+++ b/zcash_local_net/src/logs.rs
@@ -13,7 +13,7 @@ pub(crate) fn print_log(log_path: PathBuf) {
     let mut log_file = File::open(log_path).unwrap();
     let mut log = String::new();
     log_file.read_to_string(&mut log).unwrap();
-    tracing::info!("{log}");
+    tracing::trace!("{log}");
 }
 
 /// Write the stdout and stderr log of the `handle` to the `logs_dir`

--- a/zcash_local_net/src/logs.rs
+++ b/zcash_local_net/src/logs.rs
@@ -56,3 +56,16 @@ impl<T: LogsToDir> LogsToStdoutAndStderr for T {
         print_log(stdout_log_path);
     }
 }
+
+pub fn trace_version(executable_name: &str, version_command: &str) {
+    let mut command = crate::utils::executable_finder::pick_command(executable_name);
+
+    let mut args = vec![version_command];
+
+    command.args(args);
+
+    let version = command
+        .output()
+        .expect(crate::utils::executable_finder::EXPECT_SPAWN);
+    tracing::info!("lightwalletd version {version:?}");
+}

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -40,6 +40,23 @@ fn pick_path(executable_name: &str) -> Option<PathBuf> {
 /// Used to `expect` `pick_command`.
 pub(crate) const EXPECT_SPAWN: &str = "Failed to spawn command! Test executable must be set in TEST_BINARIES_DIR environment variable or be in PATH.";
 
+/// Helper to trace the executable version.
+pub fn trace_version(executable_name: &str, version_command: &str) {
+    let mut command = crate::utils::executable_finder::pick_command(executable_name);
+
+    let args = vec![version_command];
+
+    command.args(args);
+
+    let version = command
+        .output()
+        .expect(crate::utils::executable_finder::EXPECT_SPAWN);
+    tracing::info!(
+        "$ {executable_name} {version_command}
+ {version:?}"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::pick_path;

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -42,6 +42,8 @@ pub(crate) const EXPECT_SPAWN: &str = "Failed to spawn command! Test executable 
 
 #[cfg(test)]
 mod tests {
+    use super::pick_path;
+
     #[test]
     fn cargo() {
         let pick_path = pick_path("cargo");

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -25,20 +25,20 @@ fn pick_path(executable_name: &str, trace_location: bool) -> Option<PathBuf> {
             let path = PathBuf::from(directory).join(executable_name);
             if path.exists() {
                 if trace_location {
-                    tracing::warn!("Found {executable_name} at {path:?}.");
+                    tracing::info!("Found {executable_name} at {path:?}.");
                     tracing::info!("Ready to launch to launch {executable_name}.");
                 }
                 Some(path)
             } else {
                 if trace_location {
-                    tracing::warn!("Could not find {executable_name} at {path:?} set by {environment_variable_path} environment variable.");
+                    tracing::info!("Could not find {executable_name} at {path:?} set by {environment_variable_path} environment variable.");
                 }
                 None
             }
         }
         Err(_err) => {
             if trace_location {
-                tracing::warn!("{environment_variable_path} environment variable is not set.");
+                tracing::info!("{environment_variable_path} environment variable is not set.");
             }
             None
         }

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -2,10 +2,14 @@ use std::{path::PathBuf, process::Command};
 
 /// -Checks to see if an executable is in a directory determined by the `TEST_BINARIES_DIR` environment variable.
 /// or launches directly, hoping it is in path.
-pub(crate) fn pick_command(executable_name: &str) -> Command {
-    pick_path(executable_name).map_or_else(
+pub(crate) fn pick_command(executable_name: &str, trace_location: bool) -> Command {
+    pick_path(executable_name, trace_location).map_or_else(
         || {
-            tracing::info!("Trying to launch {executable_name} from PATH environment variable.");
+            if trace_location {
+                tracing::info!(
+                    "Trying to launch {executable_name} from PATH environment variable."
+                );
+            }
             Command::new(executable_name)
         },
         Command::new,
@@ -13,23 +17,29 @@ pub(crate) fn pick_command(executable_name: &str) -> Command {
 }
 
 /// The part of `pick_command` that is unit-testable.
-fn pick_path(executable_name: &str) -> Option<PathBuf> {
+fn pick_path(executable_name: &str, trace_location: bool) -> Option<PathBuf> {
     let environment_variable_path: &str = "TEST_BINARIES_DIR";
 
     match std::env::var(environment_variable_path) {
         Ok(directory) => {
             let path = PathBuf::from(directory).join(executable_name);
             if path.exists() {
-                tracing::warn!("Found {executable_name} at {path:?}.");
-                tracing::info!("Ready to launch to launch {executable_name}.");
+                if trace_location {
+                    tracing::warn!("Found {executable_name} at {path:?}.");
+                    tracing::info!("Ready to launch to launch {executable_name}.");
+                }
                 Some(path)
             } else {
-                tracing::warn!("Could not find {executable_name} at {path:?} set by {environment_variable_path} environment variable.");
+                if trace_location {
+                    tracing::warn!("Could not find {executable_name} at {path:?} set by {environment_variable_path} environment variable.");
+                }
                 None
             }
         }
         Err(_err) => {
-            tracing::warn!("{environment_variable_path} environment variable is not set.");
+            if trace_location {
+                tracing::warn!("{environment_variable_path} environment variable is not set.");
+            }
             None
         }
     }
@@ -41,8 +51,8 @@ fn pick_path(executable_name: &str) -> Option<PathBuf> {
 pub(crate) const EXPECT_SPAWN: &str = "Failed to spawn command! Test executable must be set in TEST_BINARIES_DIR environment variable or be in PATH.";
 
 /// Helper to trace the executable version.
-pub fn trace_version(executable_name: &str, version_command: &str) {
-    let mut command = crate::utils::executable_finder::pick_command(executable_name);
+pub fn trace_version_and_location(executable_name: &str, version_command: &str) {
+    let mut command = pick_command(executable_name, true);
 
     let args = vec![version_command];
 
@@ -63,13 +73,13 @@ mod tests {
 
     #[test]
     fn cargo() {
-        let pick_path = pick_path("cargo");
+        let pick_path = pick_path("cargo", true);
         assert_eq!(pick_path, None);
     }
     #[test]
     #[ignore = "Needs TEST_BINARIES_DIR to be set and contain zcashd."]
     fn zcashd() {
-        let pick_path = pick_path("zcashd");
+        let pick_path = pick_path("zcashd", true);
         assert!(pick_path.is_some());
     }
 }

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -3,15 +3,15 @@ use std::{path::PathBuf, process::Command};
 /// -Checks to see if an executable is in a directory determined by the `TEST_BINARIES_DIR` environment variable.
 /// or launches directly, hoping it is in path.
 pub(crate) fn pick_command(executable_name: &str) -> Command {
-    pick_path(executable_name)
-        .map(Command::new)
-        .unwrap_or_else(|| {
+    pick_path(executable_name).map_or_else(
+        || {
             tracing::warn!("Trying to launch {executable_name} from PATH environment variable.");
             Command::new(executable_name)
-        })
+        },
+        Command::new,
+    )
 }
 
-/// -Checks to see if an executable is in a directory determined by the `TEST_BINARIES_DIR` environment variable.
 /// The part of `pick_command` that is unit-testable.
 fn pick_path(executable_name: &str) -> Option<PathBuf> {
     let environment_variable_path: &str = "TEST_BINARIES_DIR";
@@ -37,16 +37,20 @@ fn pick_path(executable_name: &str) -> Option<PathBuf> {
 
 // be aware these helpers are not dry because of compiler whatever
 
+/// Used to `expect` `pick_command`.
 pub(crate) const EXPECT_SPAWN: &str = "Failed to spawn command! Test executable must be set in TEST_BINARIES_DIR environment variable or be in PATH.";
 
-#[test]
-fn cargo() {
-    let pick_path = pick_path("cargo");
-    assert_eq!(pick_path, None);
-}
-#[test]
-#[ignore = "Needs TEST_BINARIES_DIR to be set and contain zcashd."]
-fn zcashd() {
-    let pick_path = pick_path("zcashd");
-    assert!(pick_path.is_some());
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cargo() {
+        let pick_path = pick_path("cargo");
+        assert_eq!(pick_path, None);
+    }
+    #[test]
+    #[ignore = "Needs TEST_BINARIES_DIR to be set and contain zcashd."]
+    fn zcashd() {
+        let pick_path = pick_path("zcashd");
+        assert!(pick_path.is_some());
+    }
 }

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -1,14 +1,18 @@
 use std::{path::PathBuf, process::Command};
 
-/// -Looks for an executable in `TEST_BINARIES_DIR` environment variable-
+/// -Checks to see if an executable is in a directory determined by the `TEST_BINARIES_DIR` environment variable.
 /// or launches directly, hoping it is in path.
-pub fn pick_command(executable_name: &str) -> Command {
+pub(crate) fn pick_command(executable_name: &str) -> Command {
     pick_path(executable_name)
         .map(Command::new)
-        .unwrap_or(Command::new(executable_name))
+        .unwrap_or_else(|| {
+            tracing::warn!("Trying to launch {executable_name} from PATH environment variable.");
+            Command::new(executable_name)
+        })
 }
 
 /// -Checks to see if an executable is in a directory determined by the `TEST_BINARIES_DIR` environment variable.
+/// The part of `pick_command` that is unit-testable.
 fn pick_path(executable_name: &str) -> Option<PathBuf> {
     let environment_variable_path: &str = "TEST_BINARIES_DIR";
 
@@ -16,15 +20,16 @@ fn pick_path(executable_name: &str) -> Option<PathBuf> {
         Ok(directory) => {
             let path = PathBuf::from(directory).join(executable_name);
             if path.exists() {
-                tracing::info!("Running {executable_name} at {path:?}.");
+                tracing::warn!("Found {executable_name} at {path:?}.");
+                tracing::info!("Ready to launch to launch {executable_name}.");
                 Some(path)
             } else {
-                tracing::warn!("Could not find {executable_name} at {path:?} set by {environment_variable_path}.");
+                tracing::warn!("Could not find {executable_name} at {path:?} set by {environment_variable_path} environment variable.");
                 None
             }
         }
         Err(_err) => {
-            tracing::warn!("{environment_variable_path} environment variable is not set. Will attempt to use {executable_name} from PATH.");
+            tracing::warn!("{environment_variable_path} environment variable is not set.");
             None
         }
     }

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, process::Command};
 pub(crate) fn pick_command(executable_name: &str) -> Command {
     pick_path(executable_name).map_or_else(
         || {
-            tracing::warn!("Trying to launch {executable_name} from PATH environment variable.");
+            tracing::info!("Trying to launch {executable_name} from PATH environment variable.");
             Command::new(executable_name)
         },
         Command::new,

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -13,6 +13,7 @@ use zingo_test_vectors::{
 };
 
 use crate::logs::LogsToStdoutAndStderr;
+use crate::utils::executable_finder::trace_version;
 use crate::validator::ValidatorConfig;
 use crate::{
     config,
@@ -150,8 +151,8 @@ impl Process for Zcashd {
         .unwrap();
 
         let executable_name = "zcashd";
-        logs::trace_version(executable_name, "--version");
-        logs::trace_version("zcash-cli", "--version");
+        trace_version(executable_name, "--version");
+        trace_version("zcash-cli", "--version");
 
         let mut command = pick_command(executable_name);
         command

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -13,7 +13,7 @@ use zingo_test_vectors::{
 };
 
 use crate::logs::LogsToStdoutAndStderr;
-use crate::utils::executable_finder::trace_version;
+use crate::utils::executable_finder::trace_version_and_location;
 use crate::validator::ValidatorConfig;
 use crate::{
     config,
@@ -111,7 +111,7 @@ impl Zcashd {
     /// self.zcash_cli_command(&["generate", "1"]);
     /// ```
     pub fn zcash_cli_command(&self, args: &[&str]) -> std::io::Result<std::process::Output> {
-        let mut command = pick_command("zcash-cli");
+        let mut command = pick_command("zcash-cli", false);
 
         command.arg(format!("-conf={}", self.config_path().to_str().unwrap()));
         command.args(args).output()
@@ -151,10 +151,10 @@ impl Process for Zcashd {
         .unwrap();
 
         let executable_name = "zcashd";
-        trace_version(executable_name, "--version");
-        trace_version("zcash-cli", "--version");
+        trace_version_and_location(executable_name, "--version");
+        trace_version_and_location("zcash-cli", "--version");
 
-        let mut command = pick_command(executable_name);
+        let mut command = pick_command(executable_name, false);
         command
             .args([
                 "--printtoconsole",

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -149,7 +149,11 @@ impl Process for Zcashd {
         )
         .unwrap();
 
-        let mut command = pick_command("zcashd");
+        let executable_name = "zcashd";
+        logs::trace_version(executable_name, "--version");
+        logs::trace_version("zcash-cli", "--version");
+
+        let mut command = pick_command(executable_name);
         command
             .args([
                 "--printtoconsole",

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -7,7 +7,7 @@ use crate::{
     logs::{self, LogsToDir, LogsToStdoutAndStderr as _},
     network,
     process::Process,
-    utils::executable_finder::{pick_command, trace_version, EXPECT_SPAWN},
+    utils::executable_finder::{pick_command, trace_version_and_location, EXPECT_SPAWN},
     validator::{Validator, ValidatorConfig},
     ProcessId,
 };
@@ -170,8 +170,8 @@ impl Process for Zebrad {
         .unwrap();
 
         let executable_name = "zebrad";
-        let mut command = pick_command(executable_name);
-        trace_version(executable_name, "--version");
+        trace_version_and_location(executable_name, "--version");
+        let mut command = pick_command(executable_name, false);
         command
             .args([
                 "--config",

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -169,7 +169,9 @@ impl Process for Zebrad {
         )
         .unwrap();
 
-        let mut command = pick_command("zebrad");
+        let executable_name = "zebrad";
+        logs::trace_version(executable_name, "--version");
+        let mut command = pick_command(executable_name);
         command
             .args([
                 "--config",

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -7,7 +7,7 @@ use crate::{
     logs::{self, LogsToDir, LogsToStdoutAndStderr as _},
     network,
     process::Process,
-    utils::executable_finder::{pick_command, EXPECT_SPAWN},
+    utils::executable_finder::{pick_command, trace_version, EXPECT_SPAWN},
     validator::{Validator, ValidatorConfig},
     ProcessId,
 };
@@ -170,8 +170,8 @@ impl Process for Zebrad {
         .unwrap();
 
         let executable_name = "zebrad";
-        logs::trace_version(executable_name, "--version");
         let mut command = pick_command(executable_name);
+        trace_version(executable_name, "--version");
         command
             .args([
                 "--config",


### PR DESCRIPTION
Prob
During an integration test in another repo using zcash_local_net. I wanted to know the version and location of the executable I was using.

Solution
Uses tracing::info! to log version and path of executables launched as part of zcash_local_net.