### PR TITLE
  test(zcash_local_net): add failing audit tests for TOCTOU sites A1,…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,6 +2285,18 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -3224,7 +3236,7 @@ dependencies = [
  "clap",
  "hex",
  "insta",
- "nix",
+ "nix 0.30.1",
  "owo-colors",
  "regex",
  "ripemd 0.1.3",
@@ -5158,6 +5170,7 @@ dependencies = [
  "getset",
  "hex",
  "json",
+ "nix 0.29.0",
  "reqwest",
  "serde_json",
  "tempfile",
@@ -5494,7 +5507,7 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
  "metrics",
- "nix",
+ "nix 0.30.1",
  "openrpsee",
  "phf",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ zebra-rpc = "6.0.2"
 getset = "0.1.3"
 hex = "0.4.3"
 json = "0.12.4"
+nix = { version = "0.29", features = ["fs", "dir"] }
 reqwest = { version = "0.12", default-features = false }
 serde_json = "1.0.132"
 tempfile = "3.13.0"

--- a/zcash_local_net/Cargo.toml
+++ b/zcash_local_net/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 getset = { workspace = true }
 json = { workspace = true }
+nix = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
 tokio = { workspace = true }

--- a/zcash_local_net/src/utils.rs
+++ b/zcash_local_net/src/utils.rs
@@ -4,6 +4,8 @@ use std::{env, path::PathBuf};
 
 /// Functions for picking executables from env variables in the global runtime.
 pub mod executable_finder;
+/// FD-anchored, no-symlink-following recursive directory copy.
+pub mod safe_copy;
 pub(crate) mod type_conversions;
 
 /// Returns path to cargo manifest directory (project root)

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -83,3 +83,54 @@ mod tests {
         assert!(pick_path.is_some());
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    /// Audit tests for `CLAUDE.md` checklist item #1 — TOCTOU on
+    /// filesystem paths. See issue #256.
+    mod corrosion_mitigation {
+        mod fs_path_toctou {
+            //! Site A1: `pick_path` pre-validates the resolved path with
+            //! `.exists()` (line 26) before returning it; the caller
+            //! then execs via `Command::new(path).spawn()`. Two syscalls
+            //! on the same `&Path` → TOCTOU window between lookup and
+            //! exec.
+            //!
+            //! Mitigation: drop the `.exists()` check entirely. Let
+            //! `Command::new(...).spawn()` fail with `ENOENT`. The same
+            //! change also fixes the silent-fallback-to-`PATH` bug
+            //! observed when zainod is missing from
+            //! `TEST_BINARIES_DIR` (the wrapper currently swallows the
+            //! lookup miss and re-spawns from PATH, producing a
+            //! confusing "Failed to spawn command" error far from the
+            //! real cause).
+
+            use crate::utils::executable_finder::pick_path;
+
+            /// FAILS while `pick_path` calls `.exists()` on the
+            /// resolved path before returning. After the fix (remove
+            /// the check), `pick_path` returns `Some(<dir>/<name>)`
+            /// regardless of whether the file is present, and lookup
+            /// is decoupled from existence — the path is only bound by
+            /// a syscall at exec time.
+            #[test]
+            fn pick_path_does_not_pre_validate_with_exists() {
+                let dir = tempfile::tempdir().unwrap();
+                std::env::set_var("TEST_BINARIES_DIR", dir.path());
+
+                let absent_name = "audit_a1_nonexistent_target";
+                let resolved = pick_path(absent_name, false);
+
+                assert_eq!(
+                    resolved,
+                    Some(dir.path().join(absent_name)),
+                    "audit (issue #256, site A1): pick_path pre-validates \
+                     the resolved path with .exists() before returning. \
+                     Drop the check; let `Command::new(path).spawn()` fail \
+                     with ENOENT instead of pre-checking and triggering a \
+                     silent PATH fallback."
+                );
+            }
+        }
+    }
+}

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -17,24 +17,29 @@ pub(crate) fn pick_command(executable_name: &str, trace_location: bool) -> Comma
 }
 
 /// The part of `pick_command` that is unit-testable.
+///
+/// Resolution is decoupled from existence: when `TEST_BINARIES_DIR`
+/// is set we return `Some(<dir>/<name>)` without stat-ing the path.
+/// The caller's `Command::new(path).spawn()` is the single syscall
+/// that binds the path, closing the TOCTOU window between a
+/// redundant `.exists()` and the eventual `execve` (issue #256, A1).
+/// Same change also removes the silent `PATH` fallback when
+/// `TEST_BINARIES_DIR` is set but the binary is missing -- a missing
+/// binary now surfaces as `ENOENT` from the spawn at the resolved
+/// path instead of disappearing into the PATH lookup.
 fn pick_path(executable_name: &str, trace_location: bool) -> Option<PathBuf> {
     let environment_variable_path: &str = "TEST_BINARIES_DIR";
 
     match std::env::var(environment_variable_path) {
         Ok(directory) => {
             let path = PathBuf::from(directory).join(executable_name);
-            if path.exists() {
-                if trace_location {
-                    tracing::info!("Found {executable_name} at {path:?}.");
-                    tracing::info!("Ready to launch to launch {executable_name}.");
-                }
-                Some(path)
-            } else {
-                if trace_location {
-                    tracing::info!("Could not find {executable_name} at {path:?} set by {environment_variable_path} environment variable.");
-                }
-                None
+            if trace_location {
+                tracing::info!(
+                    "Resolved {executable_name} to {path:?} via {environment_variable_path}; \
+                     existence is verified at spawn time."
+                );
             }
+            Some(path)
         }
         Err(_err) => {
             if trace_location {
@@ -73,6 +78,10 @@ mod tests {
 
     #[test]
     fn cargo() {
+        // Pin the env-unset branch deterministically; otherwise this
+        // test depends on whatever `TEST_BINARIES_DIR` happens to be
+        // in the parent shell.
+        std::env::remove_var("TEST_BINARIES_DIR");
         let pick_path = pick_path("cargo", true);
         assert_eq!(pick_path, None);
     }

--- a/zcash_local_net/src/utils/safe_copy.rs
+++ b/zcash_local_net/src/utils/safe_copy.rs
@@ -1,0 +1,372 @@
+//! FD-anchored, no-symlink-following recursive directory copy.
+//!
+//! Closes the TOCTOU window between path resolution and writing that
+//! opens when `Path::exists()` (or a `cp -r` subprocess) re-resolves
+//! a path through attacker-controlled symlink ancestors. See issue
+//! #256 for the audit-test sites that adopt this helper.
+//!
+//! Public API:
+//!
+//! - [`open_dir_no_symlinks`] -- opens an absolute path as a
+//!   directory FD, walking each component with
+//!   `openat(O_NOFOLLOW|O_DIRECTORY)` from `/`. Refuses any symlink
+//!   ancestor; refuses `..` components and non-absolute paths.
+//!
+//! - [`safe_copy_into_new`] -- copies `trusted_src` into `dst`
+//!   (which must not exist). The path to `dst.parent()` is walked
+//!   from `/` rejecting symlink ancestors, then the leaf is created
+//!   atomically via `mkdirat`. Used by `Validator::cache_chain`
+//!   (issue #256, A2).
+//!
+//! - [`safe_copy_into_existing`] -- copies `src` into `trusted_dst`
+//!   as `trusted_dst/<src.basename>/`. The path to `src` is walked
+//!   from `/` rejecting symlink ancestors and `src.basename` itself
+//!   is opened with `O_NOFOLLOW`. Used by
+//!   `Zebrad::load_chain`/`Zcashd::load_chain` (issue #256, A3/A4).
+//!
+//! Internally the recursive copy uses only `*at` syscalls relative
+//! to FDs we hold open, so no path is re-resolved by the kernel
+//! between steps.
+
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
+use std::path::{Component, Path};
+
+use nix::dir::Dir;
+use nix::fcntl::{AtFlags, OFlag};
+use nix::sys::stat::{Mode, SFlag};
+use nix::NixPath;
+
+/// `nix::fcntl::openat` returns `RawFd` in 0.29 and takes `Option<RawFd>`
+/// for the directory FD. Wrap it once so call sites stay in
+/// `BorrowedFd`/`OwnedFd` and the `unsafe { from_raw_fd }` lives in
+/// exactly one place.
+fn openat_owned<P>(
+    dirfd: BorrowedFd<'_>,
+    path: &P,
+    flags: OFlag,
+    mode: Mode,
+) -> io::Result<OwnedFd>
+where
+    P: ?Sized + NixPath,
+{
+    let raw = nix::fcntl::openat(Some(dirfd.as_raw_fd()), path, flags, mode)?;
+    // SAFETY: openat returned a fresh FD that no one else holds.
+    Ok(unsafe { OwnedFd::from_raw_fd(raw) })
+}
+
+/// Open `path` as a directory FD, walking from `/` with
+/// `openat(O_NOFOLLOW|O_DIRECTORY)` at each component. Rejects any
+/// symlink ancestor (`ELOOP` from the kernel, surfaced as
+/// `io::Error`). Also rejects `..` components and non-absolute paths.
+pub fn open_dir_no_symlinks(path: &Path) -> io::Result<OwnedFd> {
+    if !path.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path must be absolute",
+        ));
+    }
+
+    let mut current: OwnedFd = File::open("/")?.into();
+
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => continue,
+            Component::ParentDir => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    ".. components are not allowed",
+                ));
+            }
+            Component::Prefix(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "windows path prefixes are not allowed",
+                ));
+            }
+            Component::Normal(name) => {
+                current = openat_owned(
+                    current.as_fd(),
+                    name,
+                    OFlag::O_RDONLY
+                        | OFlag::O_DIRECTORY
+                        | OFlag::O_NOFOLLOW
+                        | OFlag::O_CLOEXEC,
+                    Mode::empty(),
+                )?;
+            }
+        }
+    }
+    Ok(current)
+}
+
+/// Copy `trusted_src` (an existing directory) to `dst` (must not yet
+/// exist). `dst.parent()` is walked from `/` rejecting symlink
+/// ancestors; the leaf is created atomically via `mkdirat`; contents
+/// are copied via `*at` syscalls relative to held FDs.
+pub fn safe_copy_into_new(trusted_src: &Path, dst: &Path) -> io::Result<()> {
+    let dst_parent = dst.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "dst must have a parent")
+    })?;
+    let dst_basename = dst.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "dst must have a basename")
+    })?;
+
+    let dst_parent_fd = open_dir_no_symlinks(dst_parent)?;
+
+    nix::sys::stat::mkdirat(
+        Some(dst_parent_fd.as_raw_fd()),
+        dst_basename,
+        Mode::S_IRWXU,
+    )?;
+
+    let dst_fd: OwnedFd = openat_owned(
+        dst_parent_fd.as_fd(),
+        dst_basename,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )?;
+
+    let src_fd: OwnedFd = File::open(trusted_src)?.into();
+
+    copy_dir_contents(src_fd.as_fd(), dst_fd.as_fd())
+}
+
+/// Copy `src` (an existing directory) into `trusted_dst` (an
+/// existing directory) as `trusted_dst/<src.basename>/`. `src`'s
+/// parent is walked from `/` rejecting symlink ancestors, and
+/// `src.basename` itself is opened with `O_NOFOLLOW` -- so neither
+/// `src` nor any ancestor of `src` may be a symlink.
+pub fn safe_copy_into_existing(src: &Path, trusted_dst: &Path) -> io::Result<()> {
+    let src_parent = src.parent().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "src must have a parent")
+    })?;
+    let src_basename = src.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "src must have a basename")
+    })?;
+
+    let src_parent_fd = open_dir_no_symlinks(src_parent)?;
+
+    let src_fd: OwnedFd = openat_owned(
+        src_parent_fd.as_fd(),
+        src_basename,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )?;
+
+    let trusted_dst_fd: OwnedFd = File::open(trusted_dst)?.into();
+
+    nix::sys::stat::mkdirat(
+        Some(trusted_dst_fd.as_raw_fd()),
+        src_basename,
+        Mode::S_IRWXU,
+    )?;
+
+    let new_dst_fd: OwnedFd = openat_owned(
+        trusted_dst_fd.as_fd(),
+        src_basename,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )?;
+
+    copy_dir_contents(src_fd.as_fd(), new_dst_fd.as_fd())
+}
+
+fn copy_dir_contents(src_fd: BorrowedFd<'_>, dst_fd: BorrowedFd<'_>) -> io::Result<()> {
+    // `Dir::from_fd` takes ownership of the FD it iterates with; dup
+    // so the caller-owned src_fd remains usable for openat below.
+    let src_dup = src_fd.try_clone_to_owned()?;
+    let mut dir = Dir::from_fd(src_dup.into_raw_fd())?;
+
+    for entry_result in dir.iter() {
+        let entry = entry_result?;
+        let name = entry.file_name();
+        let name_bytes = name.to_bytes();
+        if name_bytes == b"." || name_bytes == b".." {
+            continue;
+        }
+
+        let stat = nix::sys::stat::fstatat(
+            Some(src_fd.as_raw_fd()),
+            name,
+            AtFlags::AT_SYMLINK_NOFOLLOW,
+        )?;
+
+        let mode_bits = Mode::from_bits_truncate(stat.st_mode);
+        let file_type = stat.st_mode & SFlag::S_IFMT.bits();
+
+        if file_type == SFlag::S_IFDIR.bits() {
+            nix::sys::stat::mkdirat(Some(dst_fd.as_raw_fd()), name, mode_bits)?;
+
+            let new_src: OwnedFd = openat_owned(
+                src_fd,
+                name,
+                OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+                Mode::empty(),
+            )?;
+            let new_dst: OwnedFd = openat_owned(
+                dst_fd,
+                name,
+                OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+                Mode::empty(),
+            )?;
+
+            copy_dir_contents(new_src.as_fd(), new_dst.as_fd())?;
+        } else if file_type == SFlag::S_IFREG.bits() {
+            let src_file_fd: OwnedFd = openat_owned(
+                src_fd,
+                name,
+                OFlag::O_RDONLY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
+                Mode::empty(),
+            )?;
+            let dst_file_fd: OwnedFd = openat_owned(
+                dst_fd,
+                name,
+                OFlag::O_WRONLY
+                    | OFlag::O_CREAT
+                    | OFlag::O_EXCL
+                    | OFlag::O_NOFOLLOW
+                    | OFlag::O_CLOEXEC,
+                mode_bits,
+            )?;
+
+            let mut src_file: File = src_file_fd.into();
+            let mut dst_file: File = dst_file_fd.into();
+            io::copy(&mut src_file, &mut dst_file)?;
+        } else if file_type == SFlag::S_IFLNK.bits() {
+            let target = nix::fcntl::readlinkat(Some(src_fd.as_raw_fd()), name)?;
+            nix::unistd::symlinkat(
+                target.as_os_str(),
+                Some(dst_fd.as_raw_fd()),
+                name,
+            )?;
+        } else {
+            tracing::warn!(
+                ?name,
+                "skipping non-regular non-directory entry in safe_copy"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_dir_no_symlinks_rejects_relative_path() {
+        let err = open_dir_no_symlinks(Path::new("relative")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn open_dir_no_symlinks_rejects_dotdot_components() {
+        let err = open_dir_no_symlinks(Path::new("/tmp/..")).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn open_dir_no_symlinks_rejects_symlink_ancestor() {
+        let outer = tempfile::tempdir().unwrap();
+        let real = outer.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = outer.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let through_link = link.join("");
+        let err = open_dir_no_symlinks(&through_link).unwrap_err();
+        // ELOOP becomes a FilesystemLoop / Other depending on rust
+        // version; the important thing is the call does not succeed.
+        assert!(
+            err.raw_os_error() == Some(nix::libc::ELOOP)
+                || err.raw_os_error() == Some(nix::libc::ENOTDIR),
+            "expected ELOOP/ENOTDIR, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn safe_copy_into_new_copies_nested_tree() {
+        let src_holder = tempfile::tempdir().unwrap();
+        std::fs::write(src_holder.path().join("a.txt"), b"contents A").unwrap();
+        std::fs::create_dir(src_holder.path().join("sub")).unwrap();
+        std::fs::write(src_holder.path().join("sub").join("b.txt"), b"B").unwrap();
+
+        let dst_holder = tempfile::tempdir().unwrap();
+        let dst = dst_holder.path().join("dst");
+
+        safe_copy_into_new(src_holder.path(), &dst).unwrap();
+
+        assert_eq!(std::fs::read(dst.join("a.txt")).unwrap(), b"contents A");
+        assert_eq!(std::fs::read(dst.join("sub").join("b.txt")).unwrap(), b"B");
+    }
+
+    #[test]
+    fn safe_copy_into_new_refuses_existing_dst() {
+        let src_holder = tempfile::tempdir().unwrap();
+        std::fs::write(src_holder.path().join("a"), b"a").unwrap();
+        let dst_holder = tempfile::tempdir().unwrap();
+        let dst = dst_holder.path().join("dst");
+        std::fs::create_dir(&dst).unwrap();
+
+        let err = safe_copy_into_new(src_holder.path(), &dst).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(nix::libc::EEXIST));
+    }
+
+    #[test]
+    fn safe_copy_into_new_refuses_parent_symlink() {
+        let attacker = tempfile::tempdir().unwrap();
+        let cache_holder = tempfile::tempdir().unwrap();
+        let cache_subdir = cache_holder.path().join("cache_subdir");
+        std::os::unix::fs::symlink(attacker.path(), &cache_subdir).unwrap();
+
+        let dst = cache_subdir.join("target");
+        let src_holder = tempfile::tempdir().unwrap();
+        std::fs::write(src_holder.path().join("payload"), b"x").unwrap();
+
+        safe_copy_into_new(src_holder.path(), &dst).unwrap_err();
+
+        // Attacker dir must not have received the payload.
+        assert!(!attacker.path().join("target").join("payload").exists());
+    }
+
+    #[test]
+    fn safe_copy_into_existing_copies_at_basename() {
+        let src_holder = tempfile::tempdir().unwrap();
+        let src = src_holder.path().join("src_basename");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("data.txt"), b"data").unwrap();
+
+        let dst_holder = tempfile::tempdir().unwrap();
+
+        safe_copy_into_existing(&src, dst_holder.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read(
+                dst_holder
+                    .path()
+                    .join("src_basename")
+                    .join("data.txt")
+            )
+            .unwrap(),
+            b"data"
+        );
+    }
+
+    #[test]
+    fn safe_copy_into_existing_refuses_leaf_symlink() {
+        let attacker = tempfile::tempdir().unwrap();
+        std::fs::write(attacker.path().join("PWNED"), b"attacker payload").unwrap();
+
+        let chain_cache = tempfile::tempdir().unwrap();
+        let state_link = chain_cache.path().join("state");
+        std::os::unix::fs::symlink(attacker.path(), &state_link).unwrap();
+
+        let dst_holder = tempfile::tempdir().unwrap();
+
+        safe_copy_into_existing(&state_link, dst_holder.path()).unwrap_err();
+
+        assert!(!dst_holder.path().join("state").join("PWNED").exists());
+    }
+}

--- a/zcash_local_net/src/validator.rs
+++ b/zcash_local_net/src/validator.rs
@@ -358,22 +358,24 @@ pub trait Validator: Process<Config: ValidatorConfig> + Send + Sync + std::fmt::
     fn network(&self) -> NetworkType;
 
     /// Caches chain. This stops the zcashd process.
+    ///
+    /// `chain_cache` must not already exist; its parent path is
+    /// walked from `/` with `openat(O_NOFOLLOW)` -- if any ancestor
+    /// component is a symlink the call returns `Err` and nothing is
+    /// copied. Closes the TOCTOU window the prior `assert!(!exists)`
+    /// + `cp -r` shape left open (issue #256, A2).
     fn cache_chain(
         &mut self,
         chain_cache: PathBuf,
-    ) -> impl std::future::Future<Output = std::process::Output> + Send {
+    ) -> impl std::future::Future<Output = std::io::Result<()>> + Send {
         async move {
-            assert!(!chain_cache.exists(), "chain cache already exists!");
-
             self.stop();
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
-            std::process::Command::new("cp")
-                .arg("-r")
-                .arg(self.data_dir().path())
-                .arg(chain_cache)
-                .output()
-                .unwrap()
+            crate::utils::safe_copy::safe_copy_into_new(
+                self.data_dir().path(),
+                &chain_cache,
+            )
         }
     }
 
@@ -381,12 +383,19 @@ pub trait Validator: Process<Config: ValidatorConfig> + Send + Sync + std::fmt::
     /// Returns the path to the loaded chain cache.
     ///
     /// If network is not `Regtest` variant, the chain cache will not be copied and the original cache path will be
-    /// returned instead
+    /// returned instead.
+    ///
+    /// Returns `Err` if the chain-cache subdirectory expected by the
+    /// concrete validator (e.g. `<chain_cache>/state` for Zebrad, or
+    /// `<chain_cache>/regtest` for Zcashd) is missing, is a symlink,
+    /// or has a symlink ancestor -- the implementation routes through
+    /// [`crate::utils::safe_copy::safe_copy_into_existing`] which
+    /// rejects those shapes (issue #256, A3/A4).
     fn load_chain(
         chain_cache: PathBuf,
         validator_data_dir: PathBuf,
         validator_network: NetworkType,
-    ) -> PathBuf;
+    ) -> std::io::Result<PathBuf>;
 
     /// To reveal a port.
     fn get_port(&self) -> u16;
@@ -496,7 +505,7 @@ mod unit_tests {
                     _chain_cache: PathBuf,
                     _validator_data_dir: PathBuf,
                     _validator_network: NetworkType,
-                ) -> PathBuf {
+                ) -> std::io::Result<PathBuf> {
                     unimplemented!("MockValidator: not exercised by cache_chain")
                 }
 

--- a/zcash_local_net/src/validator.rs
+++ b/zcash_local_net/src/validator.rs
@@ -391,3 +391,158 @@ pub trait Validator: Process<Config: ValidatorConfig> + Send + Sync + std::fmt::
     /// To reveal a port.
     fn get_port(&self) -> u16;
 }
+
+#[cfg(test)]
+mod unit_tests {
+    /// Audit tests for `CLAUDE.md` checklist item #1 -- TOCTOU on
+    /// filesystem paths. See issue #256.
+    mod corrosion_mitigation {
+        mod fs_path_toctou {
+            //! Site A2: `Validator::cache_chain` default impl
+            //! (`validator.rs:366`) does
+            //!   `assert!(!chain_cache.exists())` then
+            //!   `cp -r self.data_dir() chain_cache`.
+            //! Both `Path::exists()` and `cp -r` resolve symlinks in
+            //! the *parent components* of the path. If any ancestor
+            //! component of `chain_cache` is a symlink to an
+            //! attacker-controlled directory, the assertion passes
+            //! (the leaf doesn't exist under the resolved parent) and
+            //! `cp -r` writes the validator data dir at the
+            //! attacker-pointed location. Deterministic -- no race
+            //! window required.
+            //!
+            //! (A *leaf* dangling symlink at `chain_cache` itself does
+            //! not exploit: GNU `cp -r SRC_DIR dangling_symlink`
+            //! refuses with "cannot overwrite non-directory". The
+            //! parent-component symlink vector is the deterministic
+            //! one.)
+            //!
+            //! Mitigation: canonicalize the chain_cache path and
+            //! verify no parent component traversed a symlink (or
+            //! resolve the parent via `openat(O_NOFOLLOW)`-style
+            //! syscalls), and drop the `cp -r` subprocess for an
+            //! FD-anchored Rust-level recursive copy so the path is
+            //! not re-resolved by an external tool.
+
+            use crate::error::LaunchError;
+            use crate::process::Process;
+            use crate::validator::{Validator, ValidatorConfig};
+            use crate::ProcessId;
+            use std::path::PathBuf;
+            use tempfile::TempDir;
+            use zcash_protocol::PoolType;
+            use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+
+            #[derive(Debug, Default)]
+            struct MockValidatorConfig;
+
+            impl ValidatorConfig for MockValidatorConfig {
+                fn set_test_parameters(
+                    &mut self,
+                    _mine_to_pool: PoolType,
+                    _activation_heights: ActivationHeights,
+                    _chain_cache: Option<PathBuf>,
+                ) {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+            }
+
+            #[derive(Debug)]
+            struct MockValidator {
+                data_dir: TempDir,
+            }
+
+            impl Process for MockValidator {
+                const PROCESS: ProcessId = ProcessId::Empty;
+                type Config = MockValidatorConfig;
+
+                async fn launch(_config: Self::Config) -> Result<Self, LaunchError> {
+                    Ok(MockValidator {
+                        data_dir: tempfile::tempdir().unwrap(),
+                    })
+                }
+
+                fn stop(&mut self) {}
+
+                fn print_all(&self) {}
+            }
+
+            impl Validator for MockValidator {
+                async fn get_activation_heights(&self) -> ActivationHeights {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+
+                async fn generate_blocks(&self, _n: u32) -> std::io::Result<()> {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+
+                async fn get_chain_height(&self) -> u32 {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+
+                fn data_dir(&self) -> &TempDir {
+                    &self.data_dir
+                }
+
+                fn get_zcashd_conf_path(&self) -> PathBuf {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+
+                fn network(&self) -> NetworkType {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+
+                fn load_chain(
+                    _chain_cache: PathBuf,
+                    _validator_data_dir: PathBuf,
+                    _validator_network: NetworkType,
+                ) -> PathBuf {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+
+                fn get_port(&self) -> u16 {
+                    unimplemented!("MockValidator: not exercised by cache_chain")
+                }
+            }
+
+            /// FAILS while `Validator::cache_chain` trusts a
+            /// chain_cache path whose parent component is a symlink.
+            /// After the fix, the function rejects (or canonicalizes
+            /// away) symlinked ancestors and the attacker-pointed
+            /// directory is never written.
+            #[tokio::test]
+            async fn cache_chain_refuses_chain_cache_with_symlinked_parent() {
+                let mut validator = MockValidator {
+                    data_dir: tempfile::tempdir().unwrap(),
+                };
+                std::fs::write(
+                    validator.data_dir.path().join("payload"),
+                    b"validator data dir contents",
+                )
+                .unwrap();
+
+                let attacker_dir = tempfile::tempdir().unwrap();
+
+                let cache_holder = tempfile::tempdir().unwrap();
+                let cache_subdir_link = cache_holder.path().join("cache_subdir");
+                std::os::unix::fs::symlink(attacker_dir.path(), &cache_subdir_link).unwrap();
+
+                let chain_cache = cache_subdir_link.join("target");
+
+                let _ = validator.cache_chain(chain_cache).await;
+
+                // `cp -r data_dir chain_cache` with chain_cache's
+                // parent being a symlink to attacker_dir resolves to
+                // attacker_dir/target/<data_dir contents>.
+                let attacker_marker = attacker_dir.path().join("target").join("payload");
+                assert!(
+                    !attacker_marker.exists(),
+                    "audit (issue #256, site A2): cache_chain followed a \
+                     parent-directory symlink in the chain_cache path and \
+                     wrote validator data into the attacker-pointed \
+                     directory at {attacker_marker:?}"
+                );
+            }
+        }
+    }
+}

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -186,7 +186,8 @@ impl Zcashd {
                 cache,
                 data_dir.path().to_path_buf(),
                 NetworkType::Regtest(ActivationHeights::default()),
-            );
+            )
+            .expect("load_chain failed");
         }
 
         let activation_heights = config.activation_heights;
@@ -420,17 +421,16 @@ impl Validator for Zcashd {
         chain_cache: PathBuf,
         validator_data_dir: PathBuf,
         _validator_network: NetworkType,
-    ) -> PathBuf {
-        let regtest_dir = chain_cache.clone().join("regtest");
-        assert!(regtest_dir.exists(), "regtest directory not found!");
+    ) -> std::io::Result<PathBuf> {
+        let regtest_dir = chain_cache.join("regtest");
 
-        std::process::Command::new("cp")
-            .arg("-r")
-            .arg(regtest_dir)
-            .arg(validator_data_dir)
-            .output()
-            .unwrap();
-        chain_cache
+        // `safe_copy_into_existing` walks regtest_dir's parent
+        // no-symlinks and opens regtest_dir's basename with
+        // O_NOFOLLOW -- so a symlink at chain_cache/regtest can no
+        // longer redirect the read into an attacker-controlled
+        // directory the way the prior `cp -r` did (issue #256, A4).
+        crate::utils::safe_copy::safe_copy_into_existing(&regtest_dir, &validator_data_dir)?;
+        Ok(chain_cache)
     }
 
     fn get_port(&self) -> u16 {

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -443,3 +443,72 @@ impl Drop for Zcashd {
         self.stop();
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    /// Audit tests for `CLAUDE.md` checklist item #1 — TOCTOU on
+    /// filesystem paths. See issue #256.
+    mod corrosion_mitigation {
+        mod fs_path_toctou {
+            //! Site A4: `Zcashd::load_chain` (line 425) does
+            //!   `assert!(regtest_dir.exists())` then `cp -r regtest_dir
+            //!   validator_data_dir`.
+            //! `Path::exists()` follows symlinks, so a *valid* symlink
+            //! at `chain_cache/regtest` pointing at an attacker-
+            //! controlled directory passes the assertion, and `cp -r
+            //! SRC` (which also follows the symlink) reads the
+            //! attacker's files into `validator_data_dir`.
+            //! Deterministic -- no race window required.
+            //!
+            //! Mitigation: replace `.exists()` with
+            //! `fs::symlink_metadata(p)` and reject if `is_symlink()`
+            //! (or open the directory once as an FD and use `*at`
+            //! syscalls); drop the `cp -r` subprocess for an
+            //! FD-anchored Rust-level recursive copy so the path is
+            //! not re-resolved by an external tool.
+
+            use crate::validator::zcashd::Zcashd;
+            use crate::validator::Validator;
+            use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+
+            /// FAILS while `Zcashd::load_chain` trusts a symlink at
+            /// `chain_cache/regtest`. After the fix, the function
+            /// rejects the symlink (or refuses to follow it) and the
+            /// attacker's payload never reaches `validator_data_dir`.
+            #[test]
+            fn load_chain_refuses_symlinked_regtest_dir() {
+                let attacker_dir = tempfile::tempdir().unwrap();
+                std::fs::write(
+                    attacker_dir.path().join("PWNED"),
+                    b"attacker payload -- must not reach validator_data_dir",
+                )
+                .unwrap();
+
+                let chain_cache = tempfile::tempdir().unwrap();
+                let regtest_path = chain_cache.path().join("regtest");
+                std::os::unix::fs::symlink(attacker_dir.path(), &regtest_path).unwrap();
+
+                let validator_data_holder = tempfile::tempdir().unwrap();
+                let validator_data_dir = validator_data_holder.path().to_path_buf();
+
+                let _ = <Zcashd as Validator>::load_chain(
+                    chain_cache.path().to_path_buf(),
+                    validator_data_dir.clone(),
+                    NetworkType::Regtest(ActivationHeights::default()),
+                );
+
+                // `cp -r regtest_dir validator_data_dir` produces
+                // `validator_data_dir/regtest/<contents>` (the basename
+                // of the source is appended when copying a directory
+                // into an existing directory).
+                let attacker_marker = validator_data_dir.join("regtest").join("PWNED");
+                assert!(
+                    !attacker_marker.exists(),
+                    "audit (issue #256, site A4): Zcashd::load_chain followed \
+                     a symlink at chain_cache/regtest and copied attacker \
+                     payload into validator_data_dir at {attacker_marker:?}"
+                );
+            }
+        }
+    }
+}

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -621,3 +621,73 @@ impl Drop for Zebrad {
         self.stop();
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    /// Audit tests for `CLAUDE.md` checklist item #1 — TOCTOU on
+    /// filesystem paths. See issue #256.
+    mod corrosion_mitigation {
+        mod fs_path_toctou {
+            //! Site A3: `Zebrad::load_chain` (line 599) does
+            //!   `assert!(state_dir.exists())` then `cp -r state_dir
+            //!   validator_data_dir`.
+            //! `Path::exists()` follows symlinks, so a *valid* symlink
+            //! at `chain_cache/state` pointing at an attacker-controlled
+            //! directory passes the assertion, and `cp -r SRC` (which
+            //! also follows the symlink) reads the attacker's files
+            //! into `validator_data_dir`. Deterministic — no race
+            //! window required.
+            //!
+            //! Mitigation: replace `.exists()` with
+            //! `fs::symlink_metadata(p)` and reject if `is_symlink()`
+            //! (or open the directory once as an FD and use `*at`
+            //! syscalls); drop the `cp -r` subprocess for an
+            //! FD-anchored Rust-level recursive copy so the path is
+            //! not re-resolved by an external tool.
+
+            use crate::validator::regtest_test_activation_heights;
+            use crate::validator::zebrad::Zebrad;
+            use crate::validator::Validator;
+            use zingo_common_components::protocol::NetworkType;
+
+            /// FAILS while `Zebrad::load_chain` trusts a symlink at
+            /// `chain_cache/state`. After the fix, the function rejects
+            /// the symlink (or refuses to follow it) and the attacker's
+            /// payload never reaches `validator_data_dir`.
+            #[test]
+            fn load_chain_refuses_symlinked_state_dir() {
+                let attacker_dir = tempfile::tempdir().unwrap();
+                std::fs::write(
+                    attacker_dir.path().join("PWNED"),
+                    b"attacker payload -- must not reach validator_data_dir",
+                )
+                .unwrap();
+
+                let chain_cache = tempfile::tempdir().unwrap();
+                let state_path = chain_cache.path().join("state");
+                std::os::unix::fs::symlink(attacker_dir.path(), &state_path).unwrap();
+
+                let validator_data_holder = tempfile::tempdir().unwrap();
+                let validator_data_dir = validator_data_holder.path().to_path_buf();
+
+                let _ = <Zebrad as Validator>::load_chain(
+                    chain_cache.path().to_path_buf(),
+                    validator_data_dir.clone(),
+                    NetworkType::Regtest(regtest_test_activation_heights()),
+                );
+
+                // `cp -r state_dir validator_data_dir` produces
+                // `validator_data_dir/state/<contents>` (the basename
+                // of the source is appended when copying a directory
+                // into an existing directory).
+                let attacker_marker = validator_data_dir.join("state").join("PWNED");
+                assert!(
+                    !attacker_marker.exists(),
+                    "audit (issue #256, site A3): Zebrad::load_chain followed \
+                     a symlink at chain_cache/state and copied attacker \
+                     payload into validator_data_dir at {attacker_marker:?}"
+                );
+            }
+        }
+    }
+}

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -254,7 +254,8 @@ impl Zebrad {
         let working_cache_dir = data_dir.path().to_path_buf();
 
         if let Some(src) = config.chain_cache.as_ref() {
-            Self::load_chain(src.clone(), working_cache_dir.clone(), config.network_type);
+            Self::load_chain(src.clone(), working_cache_dir.clone(), config.network_type)
+                .expect("load_chain failed");
         }
 
         let ZebradPorts {
@@ -594,20 +595,19 @@ impl Validator for Zebrad {
         chain_cache: PathBuf,
         validator_data_dir: PathBuf,
         validator_network: NetworkType,
-    ) -> PathBuf {
-        let state_dir = chain_cache.clone().join("state");
-        assert!(state_dir.exists(), "state directory not found!");
+    ) -> std::io::Result<PathBuf> {
+        let state_dir = chain_cache.join("state");
 
         if matches!(validator_network, NetworkType::Regtest(_)) {
-            std::process::Command::new("cp")
-                .arg("-r")
-                .arg(state_dir)
-                .arg(validator_data_dir.clone())
-                .output()
-                .unwrap();
-            validator_data_dir
+            // `safe_copy_into_existing` walks state_dir's parent
+            // no-symlinks and opens state_dir's basename with
+            // O_NOFOLLOW -- so a symlink at chain_cache/state can no
+            // longer redirect the read into an attacker-controlled
+            // directory the way the prior `cp -r` did (issue #256, A3).
+            crate::utils::safe_copy::safe_copy_into_existing(&state_dir, &validator_data_dir)?;
+            Ok(validator_data_dir)
         } else {
-            chain_cache
+            Ok(chain_cache)
         }
     }
 

--- a/zcash_local_net/tests/testutils.rs
+++ b/zcash_local_net/tests/testutils.rs
@@ -42,7 +42,8 @@ pub async fn generate_zebrad_large_chain_cache() {
     local_net
         .validator_mut()
         .cache_chain(chain_cache_dir.join("client_rpc_tests_large"))
-        .await;
+        .await
+        .expect("cache_chain failed");
 }
 
 // FIXME: could've not been ignored, but relies on zingolib.


### PR DESCRIPTION
… A3, A4 (issue #256)

  Encode three of the four most dangerous TOCTOU sites from issue #256
  as in-source `unit_tests::corrosion_mitigation::fs_path_toctou` tests.
  Each uses a pre-placed symlink to defeat the in-tree `.exists()` check
  deterministically (no race window required), so the tests fail today
  and will go green once the underlying patterns are fixed.

  A2 (`Validator::cache_chain` default impl) is tracked in the issue
  but skipped here -- it requires a live `Validator` instance and is
  best addressed alongside the `load_chain` refactor.

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>