### PR TITLE
release: zcash_local_net 0.5.0 + regtest-launcher 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,7 +3228,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regtest-launcher"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_local_net"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "getset",
  "hex",

--- a/regtest-launcher/Cargo.toml
+++ b/regtest-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regtest-launcher"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2024"
 license = "MIT"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.95.0"

--- a/zcash_local_net/CHANGELOG.md
+++ b/zcash_local_net/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+## [0.5.0] - 2026-04-30
+
+### Deprecated
+
+### Added
+
 - `validator::Validator::CHAIN_POLL_INTERVAL` and
   `validator::Validator::CHAIN_POLL_TIMEOUT` (associated `const`s,
   defaults `100ms` and `60s`): tunable knobs consumed by the new
@@ -131,6 +141,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     in the steady state. Catches upstream Zebra regressions that
     would let one side claim ready while the other doesn't, and
     vice versa.
+- `utils::safe_copy` module (`pub fn open_dir_no_symlinks`,
+  `pub fn safe_copy_into_new`, `pub fn safe_copy_into_existing`):
+  FD-anchored, no-symlink-following recursive directory copy. Walks
+  paths with `openat(O_NOFOLLOW|O_DIRECTORY)` from `/`, using
+  `*at` syscalls relative to held FDs so paths are not re-resolved
+  by the kernel between steps. Adopted by `Validator::cache_chain`
+  and `Validator::load_chain` to close the deterministic-exploit
+  TOCTOU vectors at issue-#256 sites A2/A3/A4. Adds `nix = "0.29"`
+  (features `["fs", "dir"]`) as a regular dependency.
+- `error::LaunchError::UnsupportedZcashdCapability` and
+  `error::LaunchError::CapabilityProbeFailed` variants. Surface
+  missing zcashd capabilities (today only `-disableshieldedproving`)
+  before any state is created, with a hint pointing at the Zingolabs
+  patched fork or the `disable_shielded_proving = false` opt-out.
+  Both fold into `LaunchError::captured_output()` returning empty
+  (no in-launch logging has happened yet).
+- `validator::zcashd::ZcashdConfig::disable_wallet` (`pub bool`,
+  default `true`): launch zcashd with `-disablewallet` to skip
+  wallet keypool generation. The harness uses zcashd for chain
+  state, not wallet operations (clients drive their own wallet via
+  zingolib/zaino). `set_test_parameters` auto-flips to `false` for
+  non-Transparent mining pools so existing shielded-coinbase tests
+  keep working without caller changes. Stock zcashd flag — no
+  capability probe required.
+- Five regression tests at
+  `validator::zcashd::unit_tests::overrideable_defaults::*` pin each
+  specced `ZcashdConfig` default with a single assertion --
+  flipping a default in code (or breaking the
+  `set_test_parameters` wallet auto-flip) breaks exactly one test
+  with a message naming the spec it violates.
+- Audit-test scaffolding under
+  `unit_tests::corrosion_mitigation::fs_path_toctou::*` (per-source
+  modules in `utils::executable_finder`, `validator`,
+  `validator::zebrad`, `validator::zcashd`) -- one test per
+  TOCTOU-on-filesystem-paths site enumerated in issue #256.
+  Eight more tests at `utils::safe_copy::tests` cover the helper's
+  primitive behaviors.
+- `rust-toolchain.toml` pinning `channel = "1.95.0"` (current
+  latest stable). Was previously unpinned.
 
 ### Changed
 
@@ -153,13 +202,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All four call sites of `launch::wait`
     (`Zcashd::launch`, `Zebrad::launch`, `Lightwalletd::launch`,
     `Zainod::launch`) now `.await` the call.
-  - **API break**: `Validator::cache_chain` is now `-> impl Future + Send`
-    (was `-> std::process::Output`). Carried the same
-    `std::thread::sleep(3s)` anti-pattern in a sync default-method body
-    reachable from `async fn` test fixtures; making it async lets the
-    sleep become `tokio::time::sleep`. Sole caller (`tests/testutils.rs`)
-    updated to `.await`.
-  - Tracked in zingolabs/infrastructure#251.
+  - **API break**: `Validator::cache_chain` is now
+    `-> impl Future<Output = io::Result<()>> + Send` (was
+    `-> std::process::Output`). The `Future` came from #251 to let the
+    `std::thread::sleep(3s)` anti-pattern in the sync default-method
+    body become `tokio::time::sleep`; the `io::Result<()>` came from
+    #256 (site A2) to surface
+    `utils::safe_copy::safe_copy_into_new`'s rejection of dst paths
+    with symlinked parent components. Sole caller
+    (`tests/testutils.rs`) updated.
+  - Tracked in zingolabs/infrastructure#251 and #256.
 - **Regtest fixture default now activates NU6.1 at height 5.**
   `validator::regtest_test_activation_heights` returns
   `nu6_1: Some(5)` (was `Some(1000)`); the matching
@@ -218,6 +270,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `network::pick_unused_port(Some(p))` now panics if `p` is already
   reserved by another caller in this process. Previously a duplicate
   fixed-port reservation would silently slip through.
+- **API break**: `Validator::load_chain` return type:
+  `io::Result<PathBuf>` (was `PathBuf`). Both `Zebrad::load_chain`
+  and `Zcashd::load_chain` now route through
+  `utils::safe_copy::safe_copy_into_existing`, which opens the
+  source's basename with `O_NOFOLLOW` and walks the parent
+  no-symlinks. Closes issue-#256 sites A3 (Zebrad's
+  `chain_cache/state` symlink vector) and A4 (Zcashd's
+  `chain_cache/regtest` symlink vector). Non-test callers in
+  `Zebrad::launch_once` and `Zcashd::launch_once` keep
+  panic-on-failure semantics via inline `.expect()`.
+- `utils::executable_finder::pick_path` no longer pre-validates the
+  resolved path with `.exists()`. Eliminates the redundant-syscall
+  TOCTOU (issue #256, site A1) and the silent `PATH` fallback when
+  `TEST_BINARIES_DIR` is set but the binary is missing -- a missing
+  binary now surfaces as `ENOENT` from
+  `Command::new(path).spawn()` at the resolved path, instead of
+  disappearing into a confusing "Failed to spawn command" produced
+  by `pick_command`'s PATH fallback.
+- `Zcashd::launch` runs a pre-launch capability probe of
+  `-disableshieldedproving` when `disable_shielded_proving` is
+  `true` (the default). Patched (Zingolabs) zcashd accepts the flag
+  from `-version` and exits 0; stock zcashd exits non-zero on the
+  unknown option. Stock binaries fail fast with
+  `LaunchError::UnsupportedZcashdCapability` and a hint pointing at
+  the Zingolabs patched fork or the
+  `disable_shielded_proving = false` opt-out, instead of producing
+  a confusing failure deep in the launch retry pipeline. Probe runs
+  before any tempdirs are created. Issue #254 follow-up.
+- `zcash_local_net` crate moved from edition `2021` to edition
+  `2024` -- the workspace is uniformly on 2024 now. The two
+  test-only `std::env::set_var`/`remove_var` calls in
+  `utils::executable_finder` are wrapped in `unsafe` blocks (sound
+  under nextest's per-test-process isolation; SAFETY notes
+  document why).
+- `lib.rs` Prerequisites section: removed the stale "binaries are
+  auto-downloaded on `cargo build/check/test`" claim (no `build.rs`
+  in tree), replaced with the actual `TEST_BINARIES_DIR`
+  resolution. Added an explicit Prerequisites entry naming the
+  Zingolabs patched zcashd fork as required for the default
+  `-disableshieldedproving` fast path.
 
 ### Removed
 

--- a/zcash_local_net/Cargo.toml
+++ b/zcash_local_net/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_local_net"
-version = "0.4.0"
-edition = "2021"
+version = "0.5.0"
+edition = "2024"
 license = "MIT"
 
 [badges]

--- a/zcash_local_net/README.md
+++ b/zcash_local_net/README.md
@@ -12,23 +12,36 @@ testing in the development of:
 
 ## List of Managed Processes
 - Zebrad
-- [Zcashd](https://github.com/zcash/zcash)
+- Zcashd
 - Zainod
-- [Lightwalletd](https://github.com/zcash/lightwalletd/)
+- Lightwalletd
 
 ## Prerequisites
 
-An internet connection will be needed (during the fist build at least) in order to fetch the required testing binaries.
-The binaries will be automagically checked and downloaded on `cargo build/check/test`. If you specify `None` in a process `launch` config, these binaries will be used.
-The path to the binaries can be specified when launching a process. In that case, you are responsible for compiling the needed binaries.
-Each processes `launch` fn and [`crate::LocalNet::launch`] take config structs for defining parameters such as path
-locations.
-See the config structs for each process in validator.rs and indexer.rs for more details.
+Set `TEST_BINARIES_DIR` to a directory containing the executables
+the harness needs (`zebrad`, `zcashd`, `zcash-cli`, `zainod`,
+`lightwalletd`); otherwise each binary is resolved via `PATH`.
+Each processes `launch` fn and [`crate::LocalNet::launch`] take
+config structs for defining additional parameters; see the config
+structs for each process in `validator.rs` and `indexer.rs`.
+
+### Patched zcashd required for the default-true fast path
+
+`ZcashdConfig::disable_shielded_proving` defaults to `true`, which
+passes `-disableshieldedproving` at launch. Stock zcashd does not
+accept this flag; the harness requires the Zingolabs patched fork
+(<https://github.com/zingolabs/zcash>). `Zcashd::launch` runs a
+pre-launch capability probe that fails fast with
+[`crate::error::LaunchError::UnsupportedZcashdCapability`] if the
+resolved binary doesn't accept the flag. To use stock zcashd
+anyway, set `disable_shielded_proving = false` (slower; loads
+Sapling/Orchard proving keys at startup).
 
 ### Launching multiple processes
 
 See [`crate::LocalNet`].
 
-Current version: 0.1.0
 
-License: MIT License
+Current version: 0.5.0
+
+License: MIT

--- a/zcash_local_net/src/config.rs
+++ b/zcash_local_net/src/config.rs
@@ -288,11 +288,12 @@ NU6 = {nu6_activation_height}
                     numerator = r.numerator,
                 ));
                 if let Some(addresses) = &r.addresses
-                    && !addresses.is_empty() {
-                        let quoted: Vec<String> =
-                            addresses.iter().map(|a| format!("\"{a}\"")).collect();
-                        cfg.push_str(&format!("\naddresses = [{}]", quoted.join(", ")));
-                    }
+                    && !addresses.is_empty()
+                {
+                    let quoted: Vec<String> =
+                        addresses.iter().map(|a| format!("\"{a}\"")).collect();
+                    cfg.push_str(&format!("\naddresses = [{}]", quoted.join(", ")));
+                }
             }
         }
     }

--- a/zcash_local_net/src/config.rs
+++ b/zcash_local_net/src/config.rs
@@ -287,13 +287,12 @@ NU6 = {nu6_activation_height}
                     receiver = r.receiver.as_toml(),
                     numerator = r.numerator,
                 ));
-                if let Some(addresses) = &r.addresses {
-                    if !addresses.is_empty() {
+                if let Some(addresses) = &r.addresses
+                    && !addresses.is_empty() {
                         let quoted: Vec<String> =
                             addresses.iter().map(|a| format!("\"{a}\"")).collect();
                         cfg.push_str(&format!("\naddresses = [{}]", quoted.join(", ")));
                     }
-                }
             }
         }
     }

--- a/zcash_local_net/src/error.rs
+++ b/zcash_local_net/src/error.rs
@@ -79,6 +79,42 @@ pub enum LaunchError {
         /// Last error returned by the RPC client
         last_error: String,
     },
+    /// The pre-launch capability probe ran the binary and observed
+    /// that the requested CLI flag is rejected (binary exits
+    /// non-zero from `<binary> <flag> -version`). Surfaces the
+    /// missing-capability before any state is created so callers
+    /// see a clear, descriptive failure instead of a deep failure
+    /// downstream of the actual launch.
+    #[error(
+        "{process_name} binary does not accept `{capability}`.\n{hint}\nProbe stderr: {stderr}"
+    )]
+    UnsupportedZcashdCapability {
+        /// Process name (always `zcashd` today; field for forward
+        /// compatibility with future per-binary probes).
+        process_name: String,
+        /// The CLI flag that was probed
+        capability: &'static str,
+        /// Captured stderr from the probe invocation
+        stderr: String,
+        /// Human-readable remediation hint (fork URL, opt-out flag,
+        /// etc.)
+        hint: String,
+    },
+    /// The pre-launch capability probe failed to spawn the binary
+    /// at all (PATH/permission/etc.) — distinct from
+    /// `UnsupportedZcashdCapability` where the binary ran but
+    /// rejected the flag.
+    #[error(
+        "{process_name} capability probe for `{capability}` failed to spawn: {io_error}"
+    )]
+    CapabilityProbeFailed {
+        /// Process name
+        process_name: String,
+        /// The CLI flag that was being probed
+        capability: &'static str,
+        /// Underlying io::Error / spawn-failure description
+        io_error: String,
+    },
 }
 
 impl LaunchError {
@@ -121,7 +157,9 @@ impl LaunchError {
                 }
                 combined
             }
-            Self::RpcReadinessTimeout { .. } => String::new(),
+            Self::RpcReadinessTimeout { .. }
+            | Self::UnsupportedZcashdCapability { .. }
+            | Self::CapabilityProbeFailed { .. } => String::new(),
         }
     }
 }

--- a/zcash_local_net/src/error.rs
+++ b/zcash_local_net/src/error.rs
@@ -104,9 +104,7 @@ pub enum LaunchError {
     /// at all (PATH/permission/etc.) — distinct from
     /// `UnsupportedZcashdCapability` where the binary ran but
     /// rejected the flag.
-    #[error(
-        "{process_name} capability probe for `{capability}` failed to spawn: {io_error}"
-    )]
+    #[error("{process_name} capability probe for `{capability}` failed to spawn: {io_error}")]
     CapabilityProbeFailed {
         /// Process name
         process_name: String,

--- a/zcash_local_net/src/indexer/empty.rs
+++ b/zcash_local_net/src/indexer/empty.rs
@@ -2,11 +2,11 @@ use getset::{CopyGetters, Getters};
 use tempfile::TempDir;
 
 use crate::{
+    ProcessId,
     error::LaunchError,
     indexer::{Indexer, IndexerConfig},
     logs::LogsToStdoutAndStderr,
     process::Process,
-    ProcessId,
 };
 
 /// Empty configuration

--- a/zcash_local_net/src/indexer/lightwalletd.rs
+++ b/zcash_local_net/src/indexer/lightwalletd.rs
@@ -4,15 +4,14 @@ use getset::{CopyGetters, Getters};
 use tempfile::TempDir;
 
 use crate::{
-    config,
+    ProcessId, config,
     error::LaunchError,
     indexer::{Indexer, IndexerConfig},
     launch,
     logs::{self, LogsToDir, LogsToStdoutAndStderr as _},
     network::{self},
     process::Process,
-    utils::executable_finder::{pick_command, trace_version_and_location, EXPECT_SPAWN},
-    ProcessId,
+    utils::executable_finder::{EXPECT_SPAWN, pick_command, trace_version_and_location},
 };
 
 /// Lightwalletd configuration

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -11,14 +11,13 @@ use crate::logs::LogsToDir;
 use crate::logs::LogsToStdoutAndStderr as _;
 use crate::utils::executable_finder::trace_version_and_location;
 use crate::{
-    config,
+    ProcessId, config,
     error::LaunchError,
     indexer::{Indexer, IndexerConfig},
     launch,
     network::{self},
     process::Process,
-    utils::executable_finder::{pick_command, EXPECT_SPAWN},
-    ProcessId,
+    utils::executable_finder::{EXPECT_SPAWN, pick_command},
 };
 
 /// Zainod configuration

--- a/zcash_local_net/src/launch.rs
+++ b/zcash_local_net/src/launch.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io::Read as _, path::PathBuf, process::Child};
 
 use tempfile::TempDir;
 
-use crate::{error::LaunchError, logs, ProcessId};
+use crate::{ProcessId, error::LaunchError, logs};
 
 /// Read the captured additional-log file (if a path was configured)
 /// for a final snapshot at error-emission time. Used to populate the

--- a/zcash_local_net/src/lib.rs
+++ b/zcash_local_net/src/lib.rs
@@ -17,12 +17,24 @@
 //!
 //! # Prerequisites
 //!
-//! An internet connection will be needed (during the fist build at least) in order to fetch the required testing binaries.
-//! The binaries will be automagically checked and downloaded on `cargo build/check/test`. If you specify `None` in a process `launch` config, these binaries will be used.
-//! The path to the binaries can be specified when launching a process. In that case, you are responsible for compiling the needed binaries.
-//! Each processes `launch` fn and [`crate::LocalNet::launch`] take config structs for defining parameters such as path
-//! locations.
-//! See the config structs for each process in validator.rs and indexer.rs for more details.
+//! Set `TEST_BINARIES_DIR` to a directory containing the executables
+//! the harness needs (`zebrad`, `zcashd`, `zcash-cli`, `zainod`,
+//! `lightwalletd`); otherwise each binary is resolved via `PATH`.
+//! Each processes `launch` fn and [`crate::LocalNet::launch`] take
+//! config structs for defining additional parameters; see the config
+//! structs for each process in `validator.rs` and `indexer.rs`.
+//!
+//! ## Patched zcashd required for the default-true fast path
+//!
+//! `ZcashdConfig::disable_shielded_proving` defaults to `true`, which
+//! passes `-disableshieldedproving` at launch. Stock zcashd does not
+//! accept this flag; the harness requires the Zingolabs patched fork
+//! (<https://github.com/zingolabs/zcash>). `Zcashd::launch` runs a
+//! pre-launch capability probe that fails fast with
+//! [`crate::error::LaunchError::UnsupportedZcashdCapability`] if the
+//! resolved binary doesn't accept the flag. To use stock zcashd
+//! anyway, set `disable_shielded_proving = false` (slower; loads
+//! Sapling/Orchard proving keys at startup).
 //!
 //! ## Launching multiple processes
 //!

--- a/zcash_local_net/src/process.rs
+++ b/zcash_local_net/src/process.rs
@@ -2,7 +2,7 @@
 
 use std::future::Future;
 
-use crate::{error::LaunchError, ProcessId};
+use crate::{ProcessId, error::LaunchError};
 
 /// Processes share some behavior.
 pub trait Process: Sized {

--- a/zcash_local_net/src/utils/executable_finder.rs
+++ b/zcash_local_net/src/utils/executable_finder.rs
@@ -81,7 +81,9 @@ mod tests {
         // Pin the env-unset branch deterministically; otherwise this
         // test depends on whatever `TEST_BINARIES_DIR` happens to be
         // in the parent shell.
-        std::env::remove_var("TEST_BINARIES_DIR");
+        // SAFETY: nextest runs each test in its own process, so no
+        // other thread can be reading the env concurrently.
+        unsafe { std::env::remove_var("TEST_BINARIES_DIR") };
         let pick_path = pick_path("cargo", true);
         assert_eq!(pick_path, None);
     }
@@ -125,7 +127,9 @@ mod unit_tests {
             #[test]
             fn pick_path_does_not_pre_validate_with_exists() {
                 let dir = tempfile::tempdir().unwrap();
-                std::env::set_var("TEST_BINARIES_DIR", dir.path());
+                // SAFETY: nextest runs each test in its own process,
+                // so no other thread can be reading the env concurrently.
+                unsafe { std::env::set_var("TEST_BINARIES_DIR", dir.path()) };
 
                 let absent_name = "audit_a1_nonexistent_target";
                 let resolved = pick_path(absent_name, false);

--- a/zcash_local_net/src/utils/safe_copy.rs
+++ b/zcash_local_net/src/utils/safe_copy.rs
@@ -33,21 +33,16 @@ use std::io;
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::path::{Component, Path};
 
+use nix::NixPath;
 use nix::dir::Dir;
 use nix::fcntl::{AtFlags, OFlag};
 use nix::sys::stat::{Mode, SFlag};
-use nix::NixPath;
 
 /// `nix::fcntl::openat` returns `RawFd` in 0.29 and takes `Option<RawFd>`
 /// for the directory FD. Wrap it once so call sites stay in
 /// `BorrowedFd`/`OwnedFd` and the `unsafe { from_raw_fd }` lives in
 /// exactly one place.
-fn openat_owned<P>(
-    dirfd: BorrowedFd<'_>,
-    path: &P,
-    flags: OFlag,
-    mode: Mode,
-) -> io::Result<OwnedFd>
+fn openat_owned<P>(dirfd: BorrowedFd<'_>, path: &P, flags: OFlag, mode: Mode) -> io::Result<OwnedFd>
 where
     P: ?Sized + NixPath,
 {
@@ -89,10 +84,7 @@ pub fn open_dir_no_symlinks(path: &Path) -> io::Result<OwnedFd> {
                 current = openat_owned(
                     current.as_fd(),
                     name,
-                    OFlag::O_RDONLY
-                        | OFlag::O_DIRECTORY
-                        | OFlag::O_NOFOLLOW
-                        | OFlag::O_CLOEXEC,
+                    OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC,
                     Mode::empty(),
                 )?;
             }
@@ -106,20 +98,16 @@ pub fn open_dir_no_symlinks(path: &Path) -> io::Result<OwnedFd> {
 /// ancestors; the leaf is created atomically via `mkdirat`; contents
 /// are copied via `*at` syscalls relative to held FDs.
 pub fn safe_copy_into_new(trusted_src: &Path, dst: &Path) -> io::Result<()> {
-    let dst_parent = dst.parent().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "dst must have a parent")
-    })?;
-    let dst_basename = dst.file_name().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "dst must have a basename")
-    })?;
+    let dst_parent = dst
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "dst must have a parent"))?;
+    let dst_basename = dst
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "dst must have a basename"))?;
 
     let dst_parent_fd = open_dir_no_symlinks(dst_parent)?;
 
-    nix::sys::stat::mkdirat(
-        Some(dst_parent_fd.as_raw_fd()),
-        dst_basename,
-        Mode::S_IRWXU,
-    )?;
+    nix::sys::stat::mkdirat(Some(dst_parent_fd.as_raw_fd()), dst_basename, Mode::S_IRWXU)?;
 
     let dst_fd: OwnedFd = openat_owned(
         dst_parent_fd.as_fd(),
@@ -139,12 +127,12 @@ pub fn safe_copy_into_new(trusted_src: &Path, dst: &Path) -> io::Result<()> {
 /// `src.basename` itself is opened with `O_NOFOLLOW` -- so neither
 /// `src` nor any ancestor of `src` may be a symlink.
 pub fn safe_copy_into_existing(src: &Path, trusted_dst: &Path) -> io::Result<()> {
-    let src_parent = src.parent().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "src must have a parent")
-    })?;
-    let src_basename = src.file_name().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidInput, "src must have a basename")
-    })?;
+    let src_parent = src
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "src must have a parent"))?;
+    let src_basename = src
+        .file_name()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "src must have a basename"))?;
 
     let src_parent_fd = open_dir_no_symlinks(src_parent)?;
 
@@ -187,11 +175,8 @@ fn copy_dir_contents(src_fd: BorrowedFd<'_>, dst_fd: BorrowedFd<'_>) -> io::Resu
             continue;
         }
 
-        let stat = nix::sys::stat::fstatat(
-            Some(src_fd.as_raw_fd()),
-            name,
-            AtFlags::AT_SYMLINK_NOFOLLOW,
-        )?;
+        let stat =
+            nix::sys::stat::fstatat(Some(src_fd.as_raw_fd()), name, AtFlags::AT_SYMLINK_NOFOLLOW)?;
 
         let mode_bits = Mode::from_bits_truncate(stat.st_mode);
         let file_type = stat.st_mode & SFlag::S_IFMT.bits();
@@ -236,11 +221,7 @@ fn copy_dir_contents(src_fd: BorrowedFd<'_>, dst_fd: BorrowedFd<'_>) -> io::Resu
             io::copy(&mut src_file, &mut dst_file)?;
         } else if file_type == SFlag::S_IFLNK.bits() {
             let target = nix::fcntl::readlinkat(Some(src_fd.as_raw_fd()), name)?;
-            nix::unistd::symlinkat(
-                target.as_os_str(),
-                Some(dst_fd.as_raw_fd()),
-                name,
-            )?;
+            nix::unistd::symlinkat(target.as_os_str(), Some(dst_fd.as_raw_fd()), name)?;
         } else {
             tracing::warn!(
                 ?name,
@@ -343,13 +324,7 @@ mod tests {
         safe_copy_into_existing(&src, dst_holder.path()).unwrap();
 
         assert_eq!(
-            std::fs::read(
-                dst_holder
-                    .path()
-                    .join("src_basename")
-                    .join("data.txt")
-            )
-            .unwrap(),
+            std::fs::read(dst_holder.path().join("src_basename").join("data.txt")).unwrap(),
             b"data"
         );
     }

--- a/zcash_local_net/src/validator.rs
+++ b/zcash_local_net/src/validator.rs
@@ -257,7 +257,9 @@ fn parse_activation_heights_from_rpc(
         .set_nu6_1(get_height("NU6.1"))
         .set_nu7(get_height("NU7"))
         .build();
-    tracing::debug!("regtest validator reports the following activation heights: {configured_activation_heights:?}");
+    tracing::debug!(
+        "regtest validator reports the following activation heights: {configured_activation_heights:?}"
+    );
 
     configured_activation_heights
 }
@@ -295,7 +297,7 @@ pub trait Validator: Process<Config: ValidatorConfig> + Send + Sync + std::fmt::
     /// A representation of the Network Upgrade Activation heights applied for this
     /// Validator's test configuration.
     fn get_activation_heights(&self)
-        -> impl std::future::Future<Output = ActivationHeights> + Send;
+    -> impl std::future::Future<Output = ActivationHeights> + Send;
 
     /// Generate `n` blocks. This implementation should also call [`Self::poll_chain_height`] so the chain is at the
     /// correct height when this function returns.
@@ -372,10 +374,7 @@ pub trait Validator: Process<Config: ValidatorConfig> + Send + Sync + std::fmt::
             self.stop();
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
-            crate::utils::safe_copy::safe_copy_into_new(
-                self.data_dir().path(),
-                &chain_cache,
-            )
+            crate::utils::safe_copy::safe_copy_into_new(self.data_dir().path(), &chain_cache)
         }
     }
 
@@ -433,10 +432,10 @@ mod unit_tests {
             //! FD-anchored Rust-level recursive copy so the path is
             //! not re-resolved by an external tool.
 
+            use crate::ProcessId;
             use crate::error::LaunchError;
             use crate::process::Process;
             use crate::validator::{Validator, ValidatorConfig};
-            use crate::ProcessId;
             use std::path::PathBuf;
             use tempfile::TempDir;
             use zcash_protocol::PoolType;

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -67,6 +67,23 @@ pub struct ZcashdConfig {
     /// See zingolabs/infrastructure#254 for the diagnosis that led
     /// to this knob.
     pub disable_shielded_proving: bool,
+    /// When `true`, launch zcashd with `-disablewallet`, which skips
+    /// loading the wallet at startup. The harness uses zcashd for
+    /// chain state, not for wallet operations (clients drive their
+    /// own wallet via zingolib/zaino), so this is the correct
+    /// default for the common case.
+    ///
+    /// Default `true`. Auto-flipped to `false` by
+    /// [`ValidatorConfig::set_test_parameters`] when `mine_to_pool
+    /// != Transparent` (zcashd needs wallet code to materialize a
+    /// shielded coinbase from `mineraddress`). Tests that drive
+    /// wallet RPCs directly (`z_sendmany`, `getnewaddress`,
+    /// `z_shieldcoinbase`, etc.) must set this to `false`
+    /// themselves.
+    ///
+    /// Unlike `disable_shielded_proving`, this is a *stock* zcashd
+    /// flag — no patched fork or capability probe required.
+    pub disable_wallet: bool,
 }
 
 impl Default for ZcashdConfig {
@@ -86,6 +103,7 @@ impl Default for ZcashdConfig {
             miner_address: Some(REG_T_ADDR_FROM_ABANDONART),
             chain_cache: None,
             disable_shielded_proving: true,
+            disable_wallet: true,
         }
     }
 }
@@ -104,6 +122,13 @@ impl ValidatorConfig for ZcashdConfig {
         });
         self.activation_heights = activation_heights;
         self.chain_cache = chain_cache;
+        // Shielded coinbase needs the wallet to materialize the
+        // mineraddress output. Re-enable for non-Transparent pools
+        // so callers don't have to know about the disable_wallet
+        // default.
+        if !matches!(mine_to_pool, PoolType::Transparent) {
+            self.disable_wallet = false;
+        }
     }
 }
 
@@ -169,6 +194,46 @@ impl ZcashdPorts {
     }
 }
 
+/// Pre-launch capability probe: confirm the resolved zcashd binary
+/// accepts `-disableshieldedproving`. The Zingolabs patched fork
+/// accepts the flag and exits 0 from `-version`; stock zcashd
+/// rejects the unknown option and exits non-zero. Run from
+/// `Zcashd::launch_once` before any tempdirs are created when
+/// `ZcashdConfig::disable_shielded_proving = true` (the default), so
+/// an unpatched binary fails fast with a clear, actionable error
+/// instead of producing a confusing failure deep in the launch
+/// pipeline.
+fn ensure_disableshieldedproving_supported() -> Result<(), LaunchError> {
+    const FLAG: &str = "-disableshieldedproving";
+    let mut command = pick_command("zcashd", false);
+    command.arg(FLAG).arg("-version");
+    let output = command
+        .output()
+        .map_err(|e| LaunchError::CapabilityProbeFailed {
+            process_name: ProcessId::Zcashd.to_string(),
+            capability: FLAG,
+            io_error: e.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(LaunchError::UnsupportedZcashdCapability {
+            process_name: ProcessId::Zcashd.to_string(),
+            capability: FLAG,
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            hint: concat!(
+                "Hint: this looks like stock zcashd, which does not accept ",
+                "`-disableshieldedproving`. The Zingolabs harness defaults to ",
+                "passing this flag for the proving-key-load fast path. Either ",
+                "install the Zingolabs patched fork ",
+                "(https://github.com/zingolabs/zcash) and point TEST_BINARIES_DIR ",
+                "at it, or set ZcashdConfig::disable_shielded_proving = false ",
+                "(slower; loads Sapling/Orchard proving keys at startup)."
+            )
+            .to_string(),
+        });
+    }
+    Ok(())
+}
+
 impl Zcashd {
     /// Single launch attempt: pick a port, write the config, spawn
     /// zcashd, wait for the readiness indicator, generate genesis if
@@ -178,6 +243,10 @@ impl Zcashd {
     /// with a config whose port pins have been cleared so
     /// `ZcashdPorts::pick` re-rolls them via `network::pick_unused_port`.
     async fn launch_once(config: ZcashdConfig) -> Result<Self, LaunchError> {
+        if config.disable_shielded_proving {
+            ensure_disableshieldedproving_supported()?;
+        }
+
         let logs_dir = tempfile::tempdir().unwrap();
         let data_dir = tempfile::tempdir().unwrap();
 
@@ -234,6 +303,14 @@ impl Zcashd {
         // zingolabs/infrastructure#254.
         if config.disable_shielded_proving {
             command.arg("-disableshieldedproving");
+        }
+
+        // Skip wallet load when the launch isn't going to use wallet
+        // RPCs. Default-true; auto-flipped to false by
+        // `set_test_parameters` for non-Transparent mining pools.
+        // See `ZcashdConfig::disable_wallet`.
+        if config.disable_wallet {
+            command.arg("-disablewallet");
         }
 
         let spawn_start = std::time::Instant::now();
@@ -509,6 +586,92 @@ mod unit_tests {
                      payload into validator_data_dir at {attacker_marker:?}"
                 );
             }
+        }
+    }
+
+    /// Regression tests for `ZcashdConfig`'s overrideable defaults.
+    /// Each test pins a single specced default; flipping that
+    /// default in code without updating the spec breaks exactly one
+    /// of these tests.
+    mod overrideable_defaults {
+        use super::super::*;
+        use crate::validator::ValidatorConfig;
+
+        #[test]
+        fn default_disables_shielded_proving() {
+            assert!(
+                ZcashdConfig::default().disable_shielded_proving,
+                "ZcashdConfig::default().disable_shielded_proving must be \
+                 true: the harness's narrow zcashd scope and the \
+                 patched-fork capability probe at launch both depend on \
+                 it. Flipping this default requires a deliberate spec \
+                 change (see CHANGELOG)."
+            );
+        }
+
+        #[test]
+        fn default_disables_wallet() {
+            assert!(
+                ZcashdConfig::default().disable_wallet,
+                "ZcashdConfig::default().disable_wallet must be true: \
+                 the harness uses zcashd for chain state, not wallet \
+                 operations (clients drive their own wallet via \
+                 zingolib/zaino). Flipping this default requires a \
+                 deliberate spec change (see CHANGELOG)."
+            );
+        }
+
+        #[test]
+        fn set_test_parameters_transparent_pool_keeps_wallet_disabled() {
+            let mut config = ZcashdConfig::default();
+            config.set_test_parameters(
+                PoolType::Transparent,
+                ActivationHeights::default(),
+                None,
+            );
+            assert!(
+                config.disable_wallet,
+                "Transparent mining does not need zcashd's wallet to \
+                 materialize coinbase outputs; set_test_parameters must \
+                 preserve the default-true `disable_wallet` for \
+                 PoolType::Transparent."
+            );
+        }
+
+        #[test]
+        fn set_test_parameters_orchard_pool_enables_wallet() {
+            let mut config = ZcashdConfig::default();
+            config.set_test_parameters(
+                PoolType::ORCHARD,
+                ActivationHeights::default(),
+                None,
+            );
+            assert!(
+                !config.disable_wallet,
+                "Orchard mining needs zcashd's wallet to materialize the \
+                 shielded coinbase output from `mineraddress`; \
+                 set_test_parameters must auto-flip `disable_wallet` to \
+                 false for PoolType::ORCHARD so callers don't have to \
+                 know about the default."
+            );
+        }
+
+        #[test]
+        fn set_test_parameters_sapling_pool_enables_wallet() {
+            let mut config = ZcashdConfig::default();
+            config.set_test_parameters(
+                PoolType::SAPLING,
+                ActivationHeights::default(),
+                None,
+            );
+            assert!(
+                !config.disable_wallet,
+                "Sapling mining needs zcashd's wallet to materialize \
+                 the shielded coinbase output from `mineraddress`; \
+                 set_test_parameters must auto-flip `disable_wallet` to \
+                 false for PoolType::SAPLING so callers don't have to \
+                 know about the default."
+            );
         }
     }
 }

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -16,15 +16,14 @@ use crate::logs::LogsToStdoutAndStderr;
 use crate::utils::executable_finder::trace_version_and_location;
 use crate::validator::ValidatorConfig;
 use crate::{
-    config,
+    ProcessId, config,
     error::LaunchError,
     launch,
     logs::LogsToDir,
     network,
     process::Process,
-    utils::executable_finder::{pick_command, EXPECT_SPAWN},
+    utils::executable_finder::{EXPECT_SPAWN, pick_command},
     validator::Validator,
-    ProcessId,
 };
 
 /// Zcashd configuration
@@ -544,8 +543,8 @@ mod unit_tests {
             //! FD-anchored Rust-level recursive copy so the path is
             //! not re-resolved by an external tool.
 
-            use crate::validator::zcashd::Zcashd;
             use crate::validator::Validator;
+            use crate::validator::zcashd::Zcashd;
             use zingo_common_components::protocol::{ActivationHeights, NetworkType};
 
             /// FAILS while `Zcashd::load_chain` trusts a symlink at
@@ -624,11 +623,7 @@ mod unit_tests {
         #[test]
         fn set_test_parameters_transparent_pool_keeps_wallet_disabled() {
             let mut config = ZcashdConfig::default();
-            config.set_test_parameters(
-                PoolType::Transparent,
-                ActivationHeights::default(),
-                None,
-            );
+            config.set_test_parameters(PoolType::Transparent, ActivationHeights::default(), None);
             assert!(
                 config.disable_wallet,
                 "Transparent mining does not need zcashd's wallet to \
@@ -641,11 +636,7 @@ mod unit_tests {
         #[test]
         fn set_test_parameters_orchard_pool_enables_wallet() {
             let mut config = ZcashdConfig::default();
-            config.set_test_parameters(
-                PoolType::ORCHARD,
-                ActivationHeights::default(),
-                None,
-            );
+            config.set_test_parameters(PoolType::ORCHARD, ActivationHeights::default(), None);
             assert!(
                 !config.disable_wallet,
                 "Orchard mining needs zcashd's wallet to materialize the \
@@ -659,11 +650,7 @@ mod unit_tests {
         #[test]
         fn set_test_parameters_sapling_pool_enables_wallet() {
             let mut config = ZcashdConfig::default();
-            config.set_test_parameters(
-                PoolType::SAPLING,
-                ActivationHeights::default(),
-                None,
-            );
+            config.set_test_parameters(PoolType::SAPLING, ActivationHeights::default(), None);
             assert!(
                 !config.disable_wallet,
                 "Sapling mining needs zcashd's wallet to materialize \

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -1,18 +1,17 @@
 //! The Zebrad executable support struct and associated.
 
 use crate::{
-    config,
+    ProcessId, config,
     error::LaunchError,
     launch,
     logs::{LogsToDir, LogsToStdoutAndStderr as _},
     network,
     process::Process,
     utils::{
-        executable_finder::{pick_command, trace_version_and_location, EXPECT_SPAWN},
+        executable_finder::{EXPECT_SPAWN, pick_command, trace_version_and_location},
         type_conversions::zingo_to_zebra_activation_heights,
     },
     validator::{Validator, ValidatorConfig},
-    ProcessId,
 };
 use zcash_protocol::PoolType;
 use zingo_common_components::protocol::{ActivationHeights, NetworkType};
@@ -139,7 +138,11 @@ impl ValidatorConfig for ZebradConfig {
         activation_heights: ActivationHeights,
         chain_cache: Option<PathBuf>,
     ) {
-        assert_eq!(mine_to_pool, PoolType::Transparent, "Zebra can only mine to transparent using this test infrastructure currently, but tried to set to {mine_to_pool}");
+        assert_eq!(
+            mine_to_pool,
+            PoolType::Transparent,
+            "Zebra can only mine to transparent using this test infrastructure currently, but tried to set to {mine_to_pool}"
+        );
         self.network_type = NetworkType::Regtest(activation_heights);
         self.chain_cache = chain_cache;
     }
@@ -645,9 +648,9 @@ mod unit_tests {
             //! FD-anchored Rust-level recursive copy so the path is
             //! not re-resolved by an external tool.
 
+            use crate::validator::Validator;
             use crate::validator::regtest_test_activation_heights;
             use crate::validator::zebrad::Zebrad;
-            use crate::validator::Validator;
             use zingo_common_components::protocol::NetworkType;
 
             /// FAILS while `Zebrad::load_chain` trusts a symlink at

--- a/zcash_local_net/tests/integration.rs
+++ b/zcash_local_net/tests/integration.rs
@@ -1,12 +1,13 @@
 mod testutils;
 
+use zcash_local_net::LocalNetConfig;
 use zcash_local_net::indexer::lightwalletd::Lightwalletd;
 use zcash_local_net::process::Process;
 use zcash_local_net::protocol::ActivationHeights;
 use zcash_local_net::validator::Validator as _;
 use zcash_local_net::validator::ValidatorConfig as _;
-use zcash_local_net::LocalNetConfig;
 use zcash_local_net::{
+    LocalNet,
     indexer::{
         empty::{Empty, EmptyConfig},
         zainod::Zainod,
@@ -16,7 +17,6 @@ use zcash_local_net::{
         zcashd::Zcashd,
         zebrad::{Zebrad, ZebradConfig},
     },
-    LocalNet,
 };
 use zcash_protocol::PoolType;
 
@@ -677,7 +677,12 @@ mod launch_recovers_from_rpc_port_collision {
                 "mode: every retry attempt hit ProcessFailed (last exit={exit_status}); \
                  captured output contains expected RPC-bind signature {sig:?}"
             ),
-            (LaunchError::LaunchAborted { matched_indicator, .. }, Some(sig)) => format!(
+            (
+                LaunchError::LaunchAborted {
+                    matched_indicator, ..
+                },
+                Some(sig),
+            ) => format!(
                 "mode: every retry attempt hit indicator-scan abort (last matched_indicator={matched_indicator:?}); \
                  captured output contains expected RPC-bind signature {sig:?}"
             ),
@@ -689,7 +694,12 @@ mod launch_recovers_from_rpc_port_collision {
                 "mode: LaunchError::ProcessFailed (exit={exit_status}) — UNEXPECTED FAILURE MODE: \
                  captured output does not contain any of the expected RPC-bind signatures {stderr_signatures:?}"
             ),
-            (LaunchError::LaunchAborted { matched_indicator, .. }, None) => format!(
+            (
+                LaunchError::LaunchAborted {
+                    matched_indicator, ..
+                },
+                None,
+            ) => format!(
                 "mode: LaunchError::LaunchAborted (indicator={matched_indicator:?}) — UNEXPECTED FAILURE MODE: \
                  captured output does not contain any of the expected RPC-bind signatures {stderr_signatures:?}"
             ),

--- a/zcash_local_net/tests/testutils.rs
+++ b/zcash_local_net/tests/testutils.rs
@@ -21,11 +21,11 @@
 //! ```
 
 use zcash_local_net::{
+    LocalNet,
     indexer::lightwalletd::Lightwalletd,
     process::Process,
     utils,
-    validator::{zebrad::Zebrad, Validator as _},
-    LocalNet,
+    validator::{Validator as _, zebrad::Zebrad},
 };
 /// Generates zebrad chain cache for client RPC test fixtures requiring a large chain
 pub async fn generate_zebrad_large_chain_cache() {


### PR DESCRIPTION
## Summary

Cuts the 0.5.0 release of `zcash_local_net` and the 0.1.0 first-formal release of `regtest-launcher`. Five commits on `release`:

- `8c9dbb6` **feat(zcashd): pre-launch -disableshieldedproving probe + default-disable wallet** — pre-launch capability probe for the patched-zcashd flag with a clear `LaunchError::UnsupportedZcashdCapability` + remediation hint when the resolved binary is stock zcashd; new `ZcashdConfig::disable_wallet` (default `true`, auto-flipped by `set_test_parameters` for non-Transparent pools); five regression tests at `unit_tests::overrideable_defaults::*` pinning each specced default with one assertion each. Issue #254 follow-up.
- `2861089` **release: bump zcash_local_net to 0.5.0 + regtest-launcher to 0.1.0, edition 2024, Rust 1.95.0** — version bumps, workspace-uniform edition 2024, new `rust-toolchain.toml` pinning `channel = "1.95.0"`, two test-only `unsafe` blocks for `set_var`/`remove_var` (sound under nextest per-test-process isolation), `lib.rs` Prerequisites doc fixed (no more stale "auto-download" claim; explicit patched-zcashd note).
- `2c5bdf2` **clippy lint** + `2140ebf` **fmt** — toolchain-bump cleanup.
- `d78c4c3` **docs(zcash_local_net): finalize CHANGELOG for 0.5.0 + regenerate README** — `[Unreleased]` → `[0.5.0] - 2026-04-30` plus appended entries for the recent work; existing `cache_chain` entry updated in-place to reflect the final `Future<Output = io::Result<()>> + Send` shape; fresh empty `[Unreleased]` at top; `README.md` regenerated from `lib.rs` via `cargo readme`.

The 0.5.0 release also folds in everything that had been accumulating in `[Unreleased]` since 0.4.0, most notably the FD-anchored `utils::safe_copy` module and the `Validator::cache_chain` / `Validator::load_chain` adoption that closed the deterministic-exploit TOCTOU vectors at sites A1–A4 from issue #256, the `Validator: Send + Sync` bound, the new lockbox / funding-stream config plumbing for NU6.1 fixtures, and the `network::pick_unused_port` race fix. See `zcash_local_net/CHANGELOG.md` for the full entry.

## Cross-references

- Closes the deterministic-exploit Tier-1 set in zingolabs/infrastructure#256 (A1/A2/A3/A4); B/C-tier and A5/A6 sites stay tracked there.
- Resolves the patched-zcashd fast-fail follow-up from zingolabs/infrastructure#254.
- Lifecycle waiter cleanup tracked in zingolabs/infrastructure#251 lands as part of this release.
- Cross-repo coordination required: `zaino-common::ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS` must follow the `nu6_1=5` change (zingolabs/zaino#1076).

## Test plan

- [ ] `cargo nextest run -p zcash_local_net --lib` — all 27 lib tests pass (4 `corrosion_mitigation::fs_path_toctou` audit tests, 8 `safe_copy::tests`, 5 `overrideable_defaults` regression tests, plus pre-existing config/network/executable_finder tests).
- [ ] `cargo nextest run -p zcash_local_net --test integration` — zebrad-anchored tests pass; zcashd-anchored tests pass against the patched fork at `$TEST_BINARIES_DIR/zcashd`; zainod-anchored tests skip/fail consistent with whether zainod is present in `$TEST_BINARIES_DIR`.
- [ ] `cargo build --workspace` clean under Rust 1.95.0 + edition 2024.
- [ ] Spot-check the regenerated `zcash_local_net/README.md` reflects `Current version: 0.5.0` and the patched-zcashd Prerequisites note.

## Post-merge

After this lands on `dev`, tag `zcash_local_net_v0.5.0` (matches the existing `zcash_local_net_v0.4.0` / `_v0.3.0` scheme), optionally `regtest-launcher_v0.1.0`, then `cargo publish -p zcash_local_net`. `regtest-launcher` stays workspace-local (not published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)