### PR TITLE
chore(zingo_test_vectors): publish prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 
 # workspace
-zingo_test_vectors = { path = "zingo_test_vectors" }
+zingo_test_vectors = { path = "zingo_test_vectors", version = "0.0.1" }
 zcash_local_net = { path = "zcash_local_net" }
 
 # zingo-common

--- a/zingo_test_vectors/Cargo.toml
+++ b/zingo_test_vectors/Cargo.toml
@@ -4,8 +4,8 @@ description = "A crate that provides access to Zingo testvectors."
 version = "0.0.1"
 edition = "2024"
 authors = ["Zingolabs <zingo@zingolabs.org>"]
-repository = "https://github.com/zingolabs/zingolib"
-homepage = "https://github.com/zingolabs/zingolib"
+repository = "https://github.com/zingolabs/infrastructure"
+homepage = "https://github.com/zingolabs/infrastructure"
 license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Two minimal edits required to publish `zingo_test_vectors` to crates.io for the first time, which unblocks publishing `zcash_local_net` (currently rejected by `cargo publish` because it path-deps `zingo_test_vectors` with no version field, and `zingo_test_vectors` is not yet on crates.io).

- Workspace `Cargo.toml`: add `version = "0.0.1"` to the `zingo_test_vectors` dep declaration. `cargo publish` refuses any dep with only a `path` field — the manifest emitted to crates.io drops the path and needs a version range to pin against.
- `zingo_test_vectors/Cargo.toml`: fix `repository` and `homepage` URLs from `zingolabs/zingolib` to `zingolabs/infrastructure`. The crate was migrated into this workspace via `89e0b66` (`move zingo_test_vectors in`); the metadata still pointed at its prior home.

No code changes; no version bump (stays at `0.0.1` for the first-publish).

## Test plan

- [ ] `cargo publish --dry-run -p zingo_test_vectors --allow-dirty` validates cleanly (passes after the version-pin edit).
- [ ] `cargo nextest run --workspace --lib` still green (no functional change).

## Post-merge

1. Tag `zingo_test_vectors_v0.0.1` on the merge commit.
2. `cargo publish -p zingo_test_vectors`.
3. Resume the `zcash_local_net_v0.5.0` publish (now unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)