### PR TITLE
● Local edits ready, workspace builds clean. Summary:

### DIFF
--- a/regtest-launcher/Cargo.toml
+++ b/regtest-launcher/Cargo.toml
@@ -3,12 +3,16 @@ name = "regtest-launcher"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
+description = "Launch a local Zcash regtest network (zebrad + zainod) and continuously mine blocks. Built on zcash_local_net."
+authors = ["Zingolabs <zingo@zingolabs.org>"]
+repository = "https://github.com/zingolabs/infrastructure"
+homepage = "https://github.com/zingolabs/infrastructure"
 
 [dependencies]
 bip0039 = "0.12.0"
 clap = { version = "4.5.53", features = ["derive"] }
 hex.workspace = true
-local-net = { path = "../zcash_local_net", package = "zcash_local_net" }
+local-net = { path = "../zcash_local_net", package = "zcash_local_net", version = "0.5.0" }
 owo-colors = "4.2.3"
 ripemd = "0.1.3"
 secp256k1 = "0.29.1"

--- a/zcash_local_net/Cargo.toml
+++ b/zcash_local_net/Cargo.toml
@@ -3,6 +3,10 @@ name = "zcash_local_net"
 version = "0.5.0"
 edition = "2024"
 license = "MIT"
+description = "Utilities for launching and managing local Zcash processes (zebrad, zcashd, zainod, lightwalletd) for integration testing."
+authors = ["Zingolabs <zingo@zingolabs.org>"]
+repository = "https://github.com/zingolabs/infrastructure"
+homepage = "https://github.com/zingolabs/infrastructure"
 
 [badges]
 github = { repository = "zingolabs/infrastructure/services" }


### PR DESCRIPTION
  - zcash_local_net/Cargo.toml: added description, authors, repository, homepage. Mirrors the metadata shape already in zingo_test_vectors/Cargo.toml.
  - regtest-launcher/Cargo.toml: added the same metadata + version = "0.5.0" to the local-net (zcash_local_net) path-dep.

  Both names confirmed available on crates.io. After this lands and the in-flight zingo_test_vectors publish completes, cargo publish
  --workspace will publish all three in dep order.

  Commit message:

  chore(release): publish-prep metadata for zcash_local_net and regtest-launcher

  Adds the missing crates.io metadata (description, authors,
  repository, homepage) to both crates so their listings on crates.io
  have proper attribution rather than just a name and version. Mirrors
  the metadata shape already in `zingo_test_vectors/Cargo.toml`.

  Also adds `version = "0.5.0"` to `regtest-launcher`'s `local-net`
  (zcash_local_net) path-dep declaration, the same shape change made
  for zingo_test_vectors in 9ddb663 -- without it, `cargo publish -p
  regtest-launcher` rejects the manifest with "all dependencies must
  have a version requirement specified when publishing."

  After this lands and the in-flight zingo_test_vectors publish
  completes, all three workspace members ship from a single source-
  of-truth tree: `cargo publish --workspace` will publish them in
  dep order (zingo_test_vectors, zcash_local_net, regtest-launcher).

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>