### PR TITLE
Add zingo consensus

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,4 +3,7 @@ fail-fast = false
 
 [profile.ci]
 fail-fast = false
-default-filter = 'not (test(zebra) | test(zaino))'
+# devtool_client excluded until CI provisions the zcash-devtool binary in
+# test.yaml (the tests arrived with add_client_support and have never had
+# their binary in the runner image).
+default-filter = 'not (test(zebra) | test(zaino) | test(devtool_client))'

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -52,7 +52,9 @@ jobs:
           tool: cargo-binstall
 
       - name: Install cargo-check-external-types
-        run: cargo binstall cargo-check-external-types -y --force
+        # Pinned to match PINNED_NIGHTLY (nightly-2025-10-18, rustdoc JSON
+        # format 56). 0.5.0 requires format 57; bump both together.
+        run: cargo binstall cargo-check-external-types@0.4.0 -y --force
 
       - name: Run checks
         run: just check-external-types

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,16 @@
 This file collects conventions that AI contributors (and humans
 reviewing AI-authored work) should apply to PRs in this repository.
 
+## Tool selection
+
+Always prefer Rust-native tools in domains where they are designed to
+operate. Dependency and manifest changes go through `cargo add` /
+`cargo remove` / `cargo update`. Code navigation and refactors go
+through rust-analyzer. Verification goes through `cargo check` /
+`cargo clippy` / `cargo fmt` / `cargo nextest`. Do not reach for
+Python, sed, or regex sweeps over Rust source or `Cargo.toml` when a
+Rust tool covers the job.
+
 ## Code-review checklist: bugs Rust won't catch
 
 Memory-safety guarantees and the type system catch a lot, but the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,7 +3310,7 @@ dependencies = [
  "zcash_transparent 0.7.0",
  "zebra-node-services",
  "zebra-rpc",
- "zingo_common_components",
+ "zingo-consensus",
  "zip32",
 ]
 
@@ -5289,7 +5289,7 @@ dependencies = [
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
- "zingo_common_components",
+ "zingo-consensus",
  "zingo_test_vectors",
 ]
 
@@ -5830,13 +5830,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "zingo_common_components"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3378e81bdef45a9659736a09deaef2b5e5cb3d1556031468debfca3a21d4fa76"
-dependencies = [
- "hex",
-]
+name = "zingo-consensus"
+version = "0.1.0"
 
 [[package]]
 name = "zingo_test_vectors"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,7 +3310,6 @@ dependencies = [
  "zcash_transparent 0.7.0",
  "zebra-node-services",
  "zebra-rpc",
- "zingo-consensus",
  "zip32",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = ["zcash_local_net", "zingo_test_vectors", "regtest-launcher"]
+members = [
+    "zcash_local_net",
+    "zingo-consensus",
+    "zingo_test_vectors",
+    "regtest-launcher",
+]
 resolver = "2"
 
 [workspace.dependencies]
@@ -7,9 +12,7 @@ resolver = "2"
 # workspace
 zingo_test_vectors = { path = "zingo_test_vectors" }
 zcash_local_net = { path = "zcash_local_net" }
-
-# zingo-common
-zingo_common_components = "0.3.1"
+zingo-consensus = { path = "zingo-consensus" }
 
 #zcash
 zcash_protocol = { version = "0.9.0", features = ["local-consensus"] }

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,14 @@ all-features = false
 no-default-features = false
 exclude = ["bincode", "json"]
 
+[advisories]
+ignore = [
+    # proc-macro-error2 (unmaintained) arrives via getset, which orchard 0.14
+    # pins inside the zebra-rpc chain, so no local change can remove it from
+    # the lock. Compile-time-only proc-macro, not runtime code. Remove this
+    # entry once orchard/zebra drop getset upstream.
+    { id = "RUSTSEC-2026-0173", reason = "getset -> proc-macro-error2 pinned by orchard 0.14; no upgrade path" },
+]
 
 [bans]
 multiple-versions = "warn"

--- a/regtest-launcher/Cargo.toml
+++ b/regtest-launcher/Cargo.toml
@@ -24,7 +24,6 @@ zcash_transparent = { version = "0.7.0", features = ["transparent-inputs"] }
 zebra-node-services = { workspace = true, features = ["rpc-client"] }
 zebra-rpc.workspace = true
 zip32 = "0.2.1"
-zingo-consensus = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1.0.100"

--- a/regtest-launcher/Cargo.toml
+++ b/regtest-launcher/Cargo.toml
@@ -24,7 +24,7 @@ zcash_transparent = { version = "0.7.0", features = ["transparent-inputs"] }
 zebra-node-services = { workspace = true, features = ["rpc-client"] }
 zebra-rpc.workspace = true
 zip32 = "0.2.1"
-zingo_common_components = { workspace = true }
+zingo-consensus = { workspace = true }
 
 [dev-dependencies]
 anyhow = "1.0.100"

--- a/regtest-launcher/src/cli.rs
+++ b/regtest-launcher/src/cli.rs
@@ -367,9 +367,9 @@ mod tests {
 
         // Mirror the field-by-field conversion done in
         // regtest-launcher::main: ConfiguredActivationHeights ->
-        // zingo_common_components::ActivationHeights. `before_overwinter`
+        // zingo_consensus::ActivationHeights. `before_overwinter`
         // exists on the former but not the latter and is dropped.
-        let from_cli = zingo_common_components::protocol::ActivationHeights::builder()
+        let from_cli = zingo_consensus::ActivationHeights::builder()
             .set_overwinter(parsed.overwinter)
             .set_sapling(parsed.sapling)
             .set_blossom(parsed.blossom)

--- a/regtest-launcher/src/cli.rs
+++ b/regtest-launcher/src/cli.rs
@@ -367,9 +367,9 @@ mod tests {
 
         // Mirror the field-by-field conversion done in
         // regtest-launcher::main: ConfiguredActivationHeights ->
-        // zingo_consensus::ActivationHeights. `before_overwinter`
+        // local_net::protocol::ActivationHeights. `before_overwinter`
         // exists on the former but not the latter and is dropped.
-        let from_cli = zingo_consensus::ActivationHeights::builder()
+        let from_cli = local_net::protocol::ActivationHeights::builder()
             .set_overwinter(parsed.overwinter)
             .set_sapling(parsed.sapling)
             .set_blossom(parsed.blossom)

--- a/regtest-launcher/src/main.rs
+++ b/regtest-launcher/src/main.rs
@@ -38,7 +38,7 @@ use zebra_rpc::{
     },
     proposal_block_from_template,
 };
-use zingo_common_components::protocol::ActivationHeights;
+use zingo_consensus::ActivationHeights;
 
 use crate::{cli::Cli, keygen::generate_regtest_transparent_keypair};
 

--- a/regtest-launcher/src/main.rs
+++ b/regtest-launcher/src/main.rs
@@ -24,6 +24,7 @@ use owo_colors::OwoColorize;
 
 use tokio::{signal::ctrl_c, time::interval};
 
+use local_net::protocol::ActivationHeights;
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::{
     client::{
@@ -38,7 +39,6 @@ use zebra_rpc::{
     },
     proposal_block_from_template,
 };
-use zingo_consensus::ActivationHeights;
 
 use crate::{cli::Cli, keygen::generate_regtest_transparent_keypair};
 

--- a/zcash_local_net/Cargo.toml
+++ b/zcash_local_net/Cargo.toml
@@ -14,7 +14,7 @@ github = { repository = "zingolabs/infrastructure/services" }
 [dependencies]
 
 # zingo
-zingo_common_components = { workspace = true }
+zingo-consensus = { workspace = true }
 zingo_test_vectors = { workspace = true }
 
 # zcash
@@ -47,8 +47,9 @@ tokio = { workspace = true, features = ["macros", "fs", "rt-multi-thread"] }
 allowed_external_types = [
     "tempfile::dir::TempDir",
     "zcash_protocol::PoolType",
-    "zingo_common_components::protocol::ActivationHeights",
-    "zingo_common_components::protocol::NetworkType",
+    "zingo_consensus::ActivationHeights",
+    "zingo_consensus::ActivationHeightsBuilder",
+    "zingo_consensus::NetworkType",
     "zebra_node_services::rpc_client::RpcRequestClient",
     "reqwest::error::Error",
 ]

--- a/zcash_local_net/src/client/zcash_devtool.rs
+++ b/zcash_local_net/src/client/zcash_devtool.rs
@@ -20,7 +20,7 @@ use std::process::{Child, Stdio};
 use getset::Getters;
 use tempfile::TempDir;
 
-use zingo_common_components::protocol::NetworkType;
+use zingo_consensus::NetworkType;
 use zingo_test_vectors::seeds::{ABANDON_ART_SEED, HOSPITAL_MUSEUM_SEED};
 
 use crate::{
@@ -56,9 +56,8 @@ const AGE_IDENTITY_FILENAME: &str = "age-identity.txt";
 /// mining begins, i.e. all-at-2. The NU6.1 lockbox requirement is
 /// still satisfiable at height 2 because the default `ZebradConfig`
 /// funding stream starts depositing at the activation block itself.
-pub fn supported_regtest_activation_heights() -> zingo_common_components::protocol::ActivationHeights
-{
-    zingo_common_components::protocol::ActivationHeights::builder()
+pub fn supported_regtest_activation_heights() -> zingo_consensus::ActivationHeights {
+    zingo_consensus::ActivationHeights::builder()
         .set_overwinter(Some(1))
         .set_sapling(Some(1))
         .set_blossom(Some(1))

--- a/zcash_local_net/src/config.rs
+++ b/zcash_local_net/src/config.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
-use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+use zingo_consensus::{ActivationHeights, NetworkType};
 
 /// Convert `NetworkKind` to its config string representation
 fn network_type_to_string(network: NetworkType) -> &'static str {
@@ -387,7 +387,7 @@ zcash-conf-path: {zcashd_conf}"
 mod tests {
     use std::path::PathBuf;
 
-    use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+    use zingo_consensus::{ActivationHeights, NetworkType};
 
     use crate::logs;
 

--- a/zcash_local_net/src/error.rs
+++ b/zcash_local_net/src/error.rs
@@ -180,9 +180,9 @@ pub enum ClientError {
     UnsupportedActivationHeights {
         /// The heights requested in the client config (boxed to keep
         /// `Result<_, ClientError>` small — clippy::result_large_err)
-        configured: Box<zingo_common_components::protocol::ActivationHeights>,
+        configured: Box<zingo_consensus::ActivationHeights>,
         /// The fixture heights the client binary supports
-        expected: Box<zingo_common_components::protocol::ActivationHeights>,
+        expected: Box<zingo_consensus::ActivationHeights>,
     },
 }
 

--- a/zcash_local_net/src/indexer/zainod.rs
+++ b/zcash_local_net/src/indexer/zainod.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, process::Child};
 use getset::{CopyGetters, Getters};
 use tempfile::TempDir;
 
-use zingo_common_components::protocol::NetworkType;
+use zingo_consensus::NetworkType;
 
 use crate::logs::LogsToDir;
 use crate::logs::LogsToStdoutAndStderr as _;

--- a/zcash_local_net/src/lib.rs
+++ b/zcash_local_net/src/lib.rs
@@ -66,7 +66,7 @@ pub use zcash_protocol::PoolType;
 pub mod protocol {
     pub use zcash_protocol::PoolType;
     pub use zebra_node_services::rpc_client::RpcRequestClient;
-    pub use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+    pub use zingo_consensus::{ActivationHeights, ActivationHeightsBuilder, NetworkType};
 }
 
 /// External re-exported types.

--- a/zcash_local_net/src/utils/type_conversions.rs
+++ b/zcash_local_net/src/utils/type_conversions.rs
@@ -1,5 +1,5 @@
 use zebra_chain::parameters::testnet::ConfiguredActivationHeights;
-use zingo_common_components::protocol::ActivationHeights;
+use zingo_consensus::ActivationHeights;
 
 pub(crate) fn zingo_to_zebra_activation_heights(
     value: ActivationHeights,

--- a/zcash_local_net/src/validator.rs
+++ b/zcash_local_net/src/validator.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use tempfile::TempDir;
 use zcash_protocol::PoolType;
-use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+use zingo_consensus::{ActivationHeights, NetworkType};
 
 use crate::process::Process;
 

--- a/zcash_local_net/src/validator/zcashd.rs
+++ b/zcash_local_net/src/validator/zcashd.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 
 use zcash_protocol::PoolType;
 
-use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+use zingo_consensus::{ActivationHeights, NetworkType};
 use zingo_test_vectors::{
     REG_O_ADDR_FROM_ABANDONART, REG_T_ADDR_FROM_ABANDONART, REG_Z_ADDR_FROM_ABANDONART,
 };

--- a/zcash_local_net/src/validator/zebrad.rs
+++ b/zcash_local_net/src/validator/zebrad.rs
@@ -14,7 +14,7 @@ use crate::{
     validator::{Validator, ValidatorConfig},
 };
 use zcash_protocol::PoolType;
-use zingo_common_components::protocol::{ActivationHeights, NetworkType};
+use zingo_consensus::{ActivationHeights, NetworkType};
 use zingo_test_vectors::{
     REG_O_ADDR_FROM_ABANDONART, REG_T_ADDR_FROM_ABANDONART, ZEBRAD_DEFAULT_MINER,
 };

--- a/zingo-consensus/Cargo.toml
+++ b/zingo-consensus/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "zingo-consensus"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Zcash network-upgrade activation schedules and network identity types shared by Zingo projects."
+authors = ["Zingolabs <zingo@zingolabs.org>"]
+repository = "https://github.com/zingolabs/infrastructure"
+homepage = "https://github.com/zingolabs/infrastructure"
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[dependencies]

--- a/zingo-consensus/src/lib.rs
+++ b/zingo-consensus/src/lib.rs
@@ -1,0 +1,374 @@
+//! Zcash network-upgrade activation schedules and network identity types shared by Zingo
+//! projects.
+//!
+//! Types in this crate are intended to be suitable for use in the public API of other crates
+//! so must only include types that have a stable public API that will only increase major
+//! semver version in rare cases.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Network types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NetworkType {
+    /// Mainnet
+    Mainnet,
+    /// Testnet
+    Testnet,
+    /// Regtest
+    Regtest(ActivationHeights),
+}
+
+impl std::fmt::Display for NetworkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let chain = match self {
+            NetworkType::Mainnet => "mainnet",
+            NetworkType::Testnet => "testnet",
+            NetworkType::Regtest(_) => "regtest",
+        };
+        write!(f, "{chain}")
+    }
+}
+
+/// Network upgrade activation heights for custom testnet and regtest network configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActivationHeights {
+    overwinter: Option<u32>,
+    sapling: Option<u32>,
+    blossom: Option<u32>,
+    heartwood: Option<u32>,
+    canopy: Option<u32>,
+    nu5: Option<u32>,
+    nu6: Option<u32>,
+    nu6_1: Option<u32>,
+    nu6_2: Option<u32>,
+    nu6_3: Option<u32>,
+    nu7: Option<u32>,
+}
+
+/// The standard regtest activation schedule: every deployed network upgrade active from
+/// block 1, with undeployed upgrades unset.
+///
+/// This is the schedule formerly published as `for_test::all_height_one_nus`.
+impl Default for ActivationHeights {
+    fn default() -> Self {
+        Self::builder()
+            .set_overwinter(Some(1))
+            .set_sapling(Some(1))
+            .set_blossom(Some(1))
+            .set_heartwood(Some(1))
+            .set_canopy(Some(1))
+            .set_nu5(Some(1))
+            .set_nu6(Some(1))
+            .set_nu6_1(Some(1))
+            .set_nu6_2(Some(1))
+            .set_nu6_3(Some(1))
+            .set_nu7(None)
+            .build()
+    }
+}
+
+impl ActivationHeights {
+    /// Constructs new builder.
+    pub fn builder() -> ActivationHeightsBuilder {
+        ActivationHeightsBuilder::new()
+    }
+
+    /// Returns overwinter network upgrade activation height.
+    pub fn overwinter(&self) -> Option<u32> {
+        self.overwinter
+    }
+
+    /// Returns sapling network upgrade activation height.
+    pub fn sapling(&self) -> Option<u32> {
+        self.sapling
+    }
+
+    /// Returns blossom network upgrade activation height.
+    pub fn blossom(&self) -> Option<u32> {
+        self.blossom
+    }
+
+    /// Returns heartwood network upgrade activation height.
+    pub fn heartwood(&self) -> Option<u32> {
+        self.heartwood
+    }
+
+    /// Returns canopy network upgrade activation height.
+    pub fn canopy(&self) -> Option<u32> {
+        self.canopy
+    }
+
+    /// Returns nu5 network upgrade activation height.
+    pub fn nu5(&self) -> Option<u32> {
+        self.nu5
+    }
+
+    /// Returns nu6 network upgrade activation height.
+    pub fn nu6(&self) -> Option<u32> {
+        self.nu6
+    }
+
+    /// Returns nu6.1 network upgrade activation height.
+    pub fn nu6_1(&self) -> Option<u32> {
+        self.nu6_1
+    }
+
+    /// Returns nu6.2 network upgrade activation height.
+    pub fn nu6_2(&self) -> Option<u32> {
+        self.nu6_2
+    }
+
+    /// Returns nu6.3 network upgrade activation height.
+    pub fn nu6_3(&self) -> Option<u32> {
+        self.nu6_3
+    }
+
+    /// Returns nu7 network upgrade activation height.
+    pub fn nu7(&self) -> Option<u32> {
+        self.nu7
+    }
+}
+
+/// A builder, so that new network upgrades do not cause breaking changes to the public API.
+pub struct ActivationHeightsBuilder {
+    overwinter: Option<u32>,
+    sapling: Option<u32>,
+    blossom: Option<u32>,
+    heartwood: Option<u32>,
+    canopy: Option<u32>,
+    nu5: Option<u32>,
+    nu6: Option<u32>,
+    nu6_1: Option<u32>,
+    nu6_2: Option<u32>,
+    nu6_3: Option<u32>,
+    nu7: Option<u32>,
+}
+
+impl Default for ActivationHeightsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ActivationHeightsBuilder {
+    /// Constructs a builder with all fields set to `None`.
+    pub fn new() -> Self {
+        Self {
+            overwinter: None,
+            sapling: None,
+            blossom: None,
+            heartwood: None,
+            canopy: None,
+            nu5: None,
+            nu6: None,
+            nu6_1: None,
+            nu6_2: None,
+            nu6_3: None,
+            nu7: None,
+        }
+    }
+
+    /// Set `overwinter` field.
+    pub fn set_overwinter(mut self, height: Option<u32>) -> Self {
+        self.overwinter = height;
+
+        self
+    }
+
+    /// Set `sapling` field.
+    pub fn set_sapling(mut self, height: Option<u32>) -> Self {
+        self.sapling = height;
+
+        self
+    }
+
+    /// Set `blossom` field.
+    pub fn set_blossom(mut self, height: Option<u32>) -> Self {
+        self.blossom = height;
+
+        self
+    }
+
+    /// Set `heartwood` field.
+    pub fn set_heartwood(mut self, height: Option<u32>) -> Self {
+        self.heartwood = height;
+
+        self
+    }
+
+    /// Set `canopy` field.
+    pub fn set_canopy(mut self, height: Option<u32>) -> Self {
+        self.canopy = height;
+
+        self
+    }
+
+    /// Set `nu5` field.
+    pub fn set_nu5(mut self, height: Option<u32>) -> Self {
+        self.nu5 = height;
+
+        self
+    }
+
+    /// Set `nu6` field.
+    pub fn set_nu6(mut self, height: Option<u32>) -> Self {
+        self.nu6 = height;
+
+        self
+    }
+
+    /// Set `nu6_1` field.
+    pub fn set_nu6_1(mut self, height: Option<u32>) -> Self {
+        self.nu6_1 = height;
+
+        self
+    }
+
+    /// Set `nu6_2` field.
+    pub fn set_nu6_2(mut self, height: Option<u32>) -> Self {
+        self.nu6_2 = height;
+
+        self
+    }
+
+    /// Set `nu6_3` field.
+    pub fn set_nu6_3(mut self, height: Option<u32>) -> Self {
+        self.nu6_3 = height;
+
+        self
+    }
+
+    /// Set `nu7` field.
+    pub fn set_nu7(mut self, height: Option<u32>) -> Self {
+        self.nu7 = height;
+
+        self
+    }
+
+    /// Builds `ActivationHeights` with assertions to ensure all earlier network upgrades are active with an activation
+    /// height equal to or lower than the later network upgrades.
+    pub fn build(self) -> ActivationHeights {
+        if let Some(b) = self.sapling {
+            assert!(self.overwinter.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.blossom {
+            assert!(self.sapling.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.heartwood {
+            assert!(self.blossom.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.canopy {
+            assert!(self.heartwood.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.nu5 {
+            assert!(self.canopy.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.nu6 {
+            assert!(self.nu5.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.nu6_1 {
+            assert!(self.nu6.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.nu6_2 {
+            assert!(self.nu6_1.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.nu6_3 {
+            assert!(self.nu6_2.is_some_and(|a| a <= b));
+        }
+        if let Some(b) = self.nu7 {
+            assert!(
+                self.nu6_3
+                    .or(self.nu6_2)
+                    .or(self.nu6_1)
+                    .is_some_and(|a| a <= b)
+            );
+        }
+
+        ActivationHeights {
+            overwinter: self.overwinter,
+            sapling: self.sapling,
+            blossom: self.blossom,
+            heartwood: self.heartwood,
+            canopy: self.canopy,
+            nu5: self.nu5,
+            nu6: self.nu6,
+            nu6_1: self.nu6_1,
+            nu6_2: self.nu6_2,
+            nu6_3: self.nu6_3,
+            nu7: self.nu7,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActivationHeights;
+
+    #[test]
+    fn activation_heights_preserve_nu6_2() {
+        let heights = ActivationHeights::builder()
+            .set_overwinter(Some(1))
+            .set_sapling(Some(2))
+            .set_blossom(Some(3))
+            .set_heartwood(Some(4))
+            .set_canopy(Some(5))
+            .set_nu5(Some(6))
+            .set_nu6(Some(7))
+            .set_nu6_1(Some(8))
+            .set_nu6_2(Some(9))
+            .set_nu7(None)
+            .build();
+
+        assert_eq!(heights.nu6_2(), Some(9));
+    }
+
+    #[test]
+    #[should_panic]
+    fn activation_heights_reject_nu6_2_before_nu6_1() {
+        let _ = ActivationHeights::builder()
+            .set_nu6(Some(7))
+            .set_nu6_1(Some(8))
+            .set_nu6_2(Some(7))
+            .build();
+    }
+
+    #[test]
+    fn activation_heights_preserve_nu6_3() {
+        let heights = ActivationHeights::builder()
+            .set_overwinter(Some(1))
+            .set_sapling(Some(2))
+            .set_blossom(Some(3))
+            .set_heartwood(Some(4))
+            .set_canopy(Some(5))
+            .set_nu5(Some(6))
+            .set_nu6(Some(7))
+            .set_nu6_1(Some(8))
+            .set_nu6_2(Some(9))
+            .set_nu6_3(Some(10))
+            .set_nu7(None)
+            .build();
+
+        assert_eq!(heights.nu6_3(), Some(10));
+    }
+
+    #[test]
+    #[should_panic]
+    fn activation_heights_reject_nu6_3_before_nu6_2() {
+        let _ = ActivationHeights::builder()
+            .set_nu6(Some(7))
+            .set_nu6_1(Some(8))
+            .set_nu6_2(Some(9))
+            .set_nu6_3(Some(8))
+            .build();
+    }
+
+    #[test]
+    fn default_is_the_all_height_one_schedule() {
+        let heights = ActivationHeights::default();
+
+        assert_eq!(heights.overwinter(), Some(1));
+        assert_eq!(heights.nu6_3(), Some(1));
+        assert_eq!(heights.nu7(), None);
+    }
+}


### PR DESCRIPTION
## What

- New zero-dependency workspace member `zingo-consensus` holding `ActivationHeights`, `ActivationHeightsBuilder`, and `NetworkType`, ported from `zingo_common_components` 0.4.0 (nu6.3 included). `BlockHeight`, `TxId`, and `H0` are not ported: an org-wide audit found zero consumers.
- The all-heights-one regtest schedule is the type's documented `Default` impl, replacing the old `for_test::all_height_one_nus` helper.
- `zcash_local_net` consumes it by path and re-exports the builder alongside the two types it already re-exported, so consumers can construct the type without a direct dependency.
- `regtest-launcher` consumes the `zcash_local_net::protocol` re-exports and holds no direct dep, per the dependency rule below.
- Now that #270 landed `add_client_support` on dev, this branch merges dev and the diff is purely the zingo-consensus work. The client code's five `zingo_common_components` references are swapped to `zingo-consensus`. Note for the zaino side: zaino's `drop_zingo_common_components` branch currently pins `0a003b4` on this branch; after this merges, that pin should move to the merge commit or the release tag.

## Why

Phase 1 of the zingo-common disintegration (see `docs/DISINTEGRATION.md` in zingolabs/zingo-common). Every network upgrade currently walks a four-repo publish cascade through zingo-common. Co-locating the vocabulary with its main consumer removes one hop, and the leaf-crate shape keeps wallet builds free of the harness: zingolib pulls only this crate, behind its default-off `regtest` feature (zingolib ADR 0002).

Dependency rule: a crate that depends on `zcash_local_net` takes the vocabulary through its `protocol` re-exports and must not also directly depend on `zingo-consensus`. The only direct dependents are `zcash_local_net` itself and zingolib's optional `regtest` feature.

## Verification

`cargo check --workspace --all-features`, `cargo clippy --workspace --all-features`, and `cargo fmt --all -- --check` are clean. `cargo nextest run -p zingo-consensus` passes 5/5.

## After merge

Tag and publish `zingo-consensus` to crates.io, then flip the git pins in zingolib (`add_regtest_gate`) and zaino (`drop_zingo_common_components`) to the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
